### PR TITLE
Optimize lazy load of user logo images

### DIFF
--- a/themes/docsy/assets/scss/_custom_home.scss
+++ b/themes/docsy/assets/scss/_custom_home.scss
@@ -323,6 +323,14 @@
       width: 100%;
     }
   }
+  .swiper-lazy-preloader{
+    opacity: 0.14!important;
+    width: 14px!important;
+    height: 14px!important;
+    margin-left: -7px!important;
+    margin-top: -7px!important;
+    border-width: 1px!important;
+  }
 
   .user-swiper-container-wrapper {
     position: relative;

--- a/themes/docsy/layouts/partials/scripts-home.html
+++ b/themes/docsy/layouts/partials/scripts-home.html
@@ -40,6 +40,10 @@
 
     function initUsers(num) {
       new Swiper('.user-swiper-container', {
+        lazy: {
+          loadPrevNext: true,
+        },
+        watchSlidesVisibility: true,
         slidesPerView: num,
         slidesPerGroup: num,
         slidesPerColumn: 4,

--- a/themes/docsy/layouts/shortcodes/blocks/users.html
+++ b/themes/docsy/layouts/shortcodes/blocks/users.html
@@ -6,8 +6,9 @@
             {{ range .Site.Data.homepage.users }}
             <div class="swiper-slide">
                 <a href="{{.website }}" target="_blank">
-                <img src="{{.logo}}" alt="{{.name}}" class="swiper-lazy" data-nolightbox="true">
+                <img data-src="{{.logo}}" class="swiper-lazy" data-nolightbox="true">
                 </a>
+                <div class="swiper-lazy-preloader"></div>
             </div>
             {{end}}
         </div>


### PR DESCRIPTION

- [x] lazy load of user logo images
+ Reduce the requests number of home page loading for the first time
+ Load the user image when the second screen enters into viewable area 

screen shot：
![test](https://user-images.githubusercontent.com/21056967/104828973-d3bc9180-58a9-11eb-92f8-b114ef18bdfb.gif)