### PR TITLE
Add swck docker image repo link

### DIFF
--- a/data/dockerImages.yml
+++ b/data/dockerImages.yml
@@ -13,3 +13,8 @@
   icon: I
   description: A full-featured license tool to check and fix license headers and resolve dependencies' licenses.
   link: https://hub.docker.com/r/apache/skywalking-eyes
+
+- name: SkyWalking Cloud on Kubernetes
+  icon: K
+  description: A platform for the SkyWalking user, provisions, upgrades, maintains SkyWalking relevant components, and makes them work natively on Kubernetes.
+  link: https://hub.docker.com/r/apache/skywalking-swck


### PR DESCRIPTION
The changes intend to add the SWCK docker image repo link to the download page.