### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,10 +7,10 @@ enableRobotsTXT = true
 theme = ["docsy"]
 
 # Will give values to .Lastmod etc.
-enableGitInfo = false
+enableGitInfo = true
 
 [frontmatter]
-lastmod = ["lastmod", ":fileModTime", ":default"]
+lastmod = [":git", ":fileModTime", "lastmod", ":default"]
 # Language settings
 contentDir = "content"
 defaultContentLanguage = "en"

--- a/config.toml
+++ b/config.toml
@@ -7,10 +7,10 @@ enableRobotsTXT = true
 theme = ["docsy"]
 
 # Will give values to .Lastmod etc.
-enableGitInfo = true
+enableGitInfo = false
 
 [frontmatter]
-lastmod = []
+lastmod = ["lastmod", ":fileModTime", ":default"]
 # Language settings
 contentDir = "content"
 defaultContentLanguage = "en"


### PR DESCRIPTION
- [x] Modify the last mod timestamp

```
enableGitInfo (false)
Enable .GitInfo object for each page (if the Hugo site is versioned by Git). This will then update the Lastmod parameter for each page using the last git commit date for that content file.
```
```
:fileModTime
Fetches the date from the content file’s last modification timestamp.
```
[More about the doc](https://gohugo.io/variables/git/#lastmod)