### PR TITLE
docs: add contributor over time image in team page

### DIFF
--- a/content/team/_index.md
+++ b/content/team/_index.md
@@ -76,6 +76,10 @@ Archived
 - [SkyWalking UI](https://github.com/apache/skywalking-ui/graphs/contributors). Replaced by RocketBot UI.
 - [SkyWalking OAL tool](https://github.com/apache/skywalking-oal-tool/graphs/contributors)
 
+## Contributor over time
+
+![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?repo=apache/skywalking&merge=true)
+
 ## Becoming a Committer
 
 SkyWalking follows the Apache way to build the community. Anyone can become a committer once they have contributed sufficiently to the project and earned the trust. Read [Contributing Guides](https://github.com/apache/skywalking/blob/master/docs/en/guides/README.md) to take part in the community.

--- a/content/team/_index.md
+++ b/content/team/_index.md
@@ -78,7 +78,7 @@ Archived
 
 ## Contributor over time
 
-![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?repo=apache/skywalking&merge=true)
+<div><img style="width:100%;max-width:unset" src="https://contributor-graph-api.apiseven.com/contributors-svg?repo=apache/skywalking&merge=true"/></div>
 
 ## Becoming a Committer
 


### PR DESCRIPTION
## What is this PR for?
Add contributor over time image in team page.
The image counts the number of contributors to all skywalking-related repositories[1] and combines them into one line.

## Screenshot
![image](https://user-images.githubusercontent.com/31329157/116053677-87a19a00-a6ad-11eb-8eb1-e2f258501fdd.png)

refer issue: https://github.com/apache/skywalking/pull/6678

[1]skywalking-related repositories: apache/skywalking,apache/skywalking-website,apache/skywalking-kubernetes,apache/skywalking-rocketbot-ui,apache/skywalking-query-protocol,apache/skywalking-nginx-lua,apache/skywalking-ui,apache/skywalking-cli,apache/skywalking-data-collect-protocol,apache/skywalking-python,apache/skywalking-docker,apache/skywalking-nodejs,apache/skywalking-satellite,apache/skywalking-swck,apache/skywalking-client-js,apache/skywalking-banyandb,apache/skywalking-agent-test-tool,apache/skywalking-rust,apache/skywalking-eyes,apache/skywalking-infra-e2e,apache/skywalking-oal-tool,apache/skywalking-goapi,apache/skywalking-kubernetes-event-exporter,apache/skywalking-kong