### PR TITLE
chore: Update config.toml about markup

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,6 +58,9 @@ id = "UA-178891182-1"
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
+  [markup.tableOfContents]
+    endLevel = 3
+    startLevel = 1
 
 # Everything below this are Site Params
 

--- a/themes/docsy/assets/scss/_sidebar-toc.scss
+++ b/themes/docsy/assets/scss/_sidebar-toc.scss
@@ -32,7 +32,7 @@
     }
 
     li li {
-        margin-left: 1rem;
+        margin-left: 0.7rem;
         line-height: 1.2;
         padding: 0.25rem;
         &:last-child{


### PR DESCRIPTION
The heading level, values starting at 1 (h1), to start render the table of contents.
[https://gohugo.io/getting-started/configuration-markup/#table-of-contents](url)