### PR TITLE
Add Showcase

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -1,3 +1,13 @@
+- type: Quick Start
+  description:
+  list:
+    - name: SkyWalking Showcase
+      icon: S
+      description: The showcase deploys multiple languages distributed system and major SkyWalking components used to demonstrate various SkyWalking features.
+      user: apache
+      repo: skywalking-showcase
+      repoUrl: https://github.com/apache/skywalking-showcase.git
+
 - type: General
   description:
   list:


### PR DESCRIPTION
I have tested this latest showcase locally. With a little local setup, it runs as expected.

The next steps(TODO) are
1. Make sure document is good to host on skywalking.apache.org/showcase/latest(or version), with documents, logs, menu. Could take this Istio page as reference, https://istio.io/latest/docs/examples/bookinfo/
2. Update the website setup 
3. Make service mesh deployment option ready to go on kubernetes deployment option
4. Update all quick start on the website, especially home page to latest showcase doc.

Wait for showcase ready