### PR TITLE
Add Rust repo to the official website

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -119,6 +119,15 @@
         - version: v0.7.0
           link: https://github.com/apache/skywalking-client-js/tree/v0.7.0
 
+    - name: Rust Agent
+      icon: R
+      description: The Rust Agent for Apache SkyWalking, which provides the native tracing abilities for Rust project.
+      user: apache
+      repo: skywalking-rust
+      docs:
+        - version: latest
+          link: https://github.com/apache/skywalking-rust
+
     - name: SkyWalking Satellite
       icon: S
       description: A lightweight collector/sidecar could be deployed closing to the target monitored system, to collect metrics, traces, and logs.


### PR DESCRIPTION
@Shikugawa I am adding this repo to the website, https://skywalking.apache.org/docs/