### PR TITLE
Align `docs` buttons to the right

### DIFF
--- a/themes/docsy/assets/scss/_custom_docs.scss
+++ b/themes/docsy/assets/scss/_custom_docs.scss
@@ -140,6 +140,7 @@
       position: absolute;
       bottom: 20px;
       left: 0;
+      justify-content: space-between;
 
       .gh-text {
         font-size: 12px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21056967/151897357-bc0d784d-c028-4630-b95d-96234f7027c2.png)
