### PR TITLE
Add Privacy notice

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -221,8 +221,14 @@ weight = 1
 
 [[menu.main]]
     parent = "Links"
-    name = "Thanks"
+    name = "Privacy Policy"
     weight = 10
+    url = "https://privacy.apache.org/policies/privacy-policy-public.html"
+
+[[menu.main]]
+    parent = "Links"
+    name = "Thanks"
+    weight = 11
     url = "http://www.apache.org/foundation/thanks.html"
 
 [params.links]


### PR DESCRIPTION
<img width="352" alt="image" src="https://user-images.githubusercontent.com/16631152/164461626-0055fa31-c2c5-49ca-94d4-4f853a0c83f0.png">
All websites run by the ASF must be compliant with the new website privacy policy and add a link to it:
https://privacy.apache.org/policies/privacy-policy-public.html

Please remove all “custom” privacy policies.

For further changes we have established a FAQ:
https://privacy.apache.org/faq/committers.html