### PR TITLE
Add translation repo to the page.

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -385,7 +385,7 @@
       repo: uranus
 
     - name: (out-dated) CN Documentations
-      description: The CN translation version of Apache SkyWalking document. This is NOT official docs, and has been out dated for years.
+      description: The CN translation version of Apache SkyWalking document. This is NOT official docs, and has been out-dated for years.
       user: SkyAPM
       repo: document-cn-translation-of-skywalking
     

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -384,7 +384,7 @@
       user: SkyAPM
       repo: uranus
 
-    - name: (out dated) SkyAPM Node.js
+    - name: (out-dated) CN Documentations
       description: The CN translation version of Apache SkyWalking document. This is NOT official docs, and has been out dated for years.
       user: SkyAPM
       repo: document-cn-translation-of-skywalking

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -384,6 +384,11 @@
       user: SkyAPM
       repo: uranus
 
+    - name: (out dated) SkyAPM Node.js
+      description: The CN translation version of Apache SkyWalking document. This is NOT official docs, and has been out dated for years.
+      user: SkyAPM
+      repo: document-cn-translation-of-skywalking
+    
     - name: (Retired) SkyAPM Node.js
       description: SkyAPM Node.js is the Node.js instrumentation agent, this project wouldn't have any update, it has been retired and archived.
       user: SkyAPM


### PR DESCRIPTION
The Translation doc is outdated, https://github.com/SkyAPM/document-cn-translation-of-skywalking.

We may consider using an open-source program to provide a translation version for the latest v9.