### PR TITLE
fix skywalking java agent download url

### DIFF
--- a/data/releases.yml
+++ b/data/releases.yml
@@ -171,16 +171,16 @@
           date: Nov. 9th, 2022
           downloadLink:
             - name: tar
-              link: https://archive.apache.org/distskywalking/java-agent/8.13.0/apache-skywalking-java-agent-8.13.0.tgz
+              link: https://archive.apache.org/dist/skywalking/java-agent/8.13.0/apache-skywalking-java-agent-8.13.0.tgz
             - name: asc
-              link: https://archive.apache.org/distskywalking/java-agent/8.13.0/apache-skywalking-java-agent-8.13.0.tgz.asc
+              link: https://archive.apache.org/dist/skywalking/java-agent/8.13.0/apache-skywalking-java-agent-8.13.0.tgz.asc
             - name: sha512
-              link: https://archive.apache.org/distskywalking/java-agent/8.13.0/apache-skywalking-java-agent-8.13.0.tgz.sha512
+              link: https://archive.apache.org/dist/skywalking/java-agent/8.13.0/apache-skywalking-java-agent-8.13.0.tgz.sha512
         - version: v8.12.0
           date: Sep. 4th, 2022
           downloadLink:
             - name: tar
-              link: https://archive.apache.org/distskywalking/java-agent/8.12.0/apache-skywalking-java-agent-8.12.0.tgz
+              link: https://archive.apache.org/dist/skywalking/java-agent/8.12.0/apache-skywalking-java-agent-8.12.0.tgz
             - name: asc
               link: https://archive.apache.org/dist/skywalking/java-agent/8.12.0/apache-skywalking-java-agent-8.12.0.tgz.asc
             - name: sha512


### PR DESCRIPTION
get 404 when visit the download page [https://skywalking.apache.org/downloads/] java agent , due to wrong url