### PR TITLE
Update Hugo Configuration and Remove Deprecated Templates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,6 +64,18 @@ id = "UA-178891182-1"
   [markup.highlight]
     style = "github"
 
+[outputs]
+  home = ["HTML", "RSS", "JSON"]
+  section = ["HTML"]
+
+[outputFormats]
+    [outputFormats.RSS]
+        baseName = "feed"
+    [outputFormats.JSON]
+        mediatype = "application/json"
+        baseName = "searchindex"
+        isPlainText = true
+
 # Everything below this are Site Params
 
 [params]

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,0 +1,6 @@
+{{- $.Scratch.Add "index" slice -}}
+{{- range .Site.RegularPages -}}
+  {{- $.Scratch.Add "index" (dict "title" .Title "url" .RelPermalink "content" .Plain) -}}
+{{- end -}}
+{{- $.Scratch.Get "index" | jsonify -}}
+

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "devDependencies": {
     "autoprefixer": "^9.8.6",
     "cssnano": "^4.1.10",
-    "postcss-cli": "^8.3.1",
     "postcss": "^8.2.6",
+    "postcss-cli": "^8.3.1",
     "postcss-cssnext": "^3.1.0",
     "postcss-import": "^12.0.1",
     "postcss-loader": "^3.0.0"

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -20,10 +20,8 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
-{{- template "_internal/google_analytics_async.html" . -}}
 {{ partialCached "head-css.html" . "asdf" }}
 <script src="/js/jquery-3.6.0.min.js"></script>
 {{ if and (.Site.Params.offlineSearch) (not .Site.Params.gcs_engine_id) }}


### PR DESCRIPTION
1. Remove unsupported templates: Removed the deprecated internal templates, "google_news" and "google_analytics_async," which are no longer supported in the latest version of Hugo. This change addresses compilation failures caused by their presence.
2. Update Hugo configuration: Added JSON export settings and implemented JSON data formatting for better query support.