### PR TITLE
Add edit this page and update committer list

### DIFF
--- a/content/team/_index.md
+++ b/content/team/_index.md
@@ -96,19 +96,20 @@ The SkyWalking team is comprised of Members and Contributors, and the growth has
 </div>
 <div class="table-box">
 
-| Name              | Apache ID   |                                                  |
-| ----------------- | ----------- | ------------------------------------------------ |
-| Ruixian Wang      | ax1an       | <i class="iconfont icon-twitter"></i> [Ax1anRISE](https://twitter.com/Ax1anRISE)       |
-| Sheng Wang        | wangsheng   |                                                  |
-| Tomasz Pytel      | tompytel    |                                                  |
-| Wei Hua           | alonelaval  |                                                  |
-| Wei Jin           | kvn         |                                                  |
-| Weijie Zou        | kdump       | <i class="iconfont icon-twitter"></i> [RootShellExp](https://twitter.com/RootShellExp) |
-| Weiyi Liu         | wayilau     |                                                  |
-| Xiang Wei         | weixiang1862|                                                  |
-| Yueqin Zhang      | yswdqz      |                                                  |
-| Yuntao Li         | liyuntao    |                                                  |
-| Zhusheng Xu       | aderm       |                                                  |
+| Name         | Apache ID    |                                                                                          |
+|--------------|--------------|------------------------------------------------------------------------------------------|
+| Ruixian Wang | ax1an        | <i class="iconfont icon-twitter"></i> [Ax1anRISE](https://twitter.com/Ax1anRISE)         |
+| Sheng Wang   | wangsheng    |                                                                                          |
+| Tomasz Pytel | tompytel     |                                                                                          |
+| Wei Hua      | alonelaval   |                                                                                          |
+| Wei Jin      | kvn          |                                                                                          |
+| Weijie Zou   | kdump        | <i class="iconfont icon-twitter"></i> [RootShellExp](https://twitter.com/RootShellExp)   |
+| Weiyi Liu    | wayilau      |                                                                                          |
+| Xiang Wei    | weixiang1862 |                                                                                          |
+| Yueqin Zhang | yswdqz       |                                                                                          |
+| Yuntao Li    | liyuntao     |                                                                                          |
+| Zhusheng Xu  | aderm        |                                                                                          |
+| Zixin Zhou   | zhouzixin    | <i class="iconfont icon-twitter"></i> [starry_loveee](https://twitter.com/starry_loveee) |
 
 </div>
 </div>

--- a/themes/docsy/layouts/partials/edit-this-page.html
+++ b/themes/docsy/layouts/partials/edit-this-page.html
@@ -1,0 +1,51 @@
+<div>
+  {{ $File := .File }}
+  {{ $Site := .Site }}
+  {{ with $File.Path }}
+  <div id="edit-github">
+    <svg
+      fill="currentColor"
+      height="20"
+      width="20"
+      viewBox="0 0 40 40"
+      aria-hidden="true"
+      style="margin-right: 0.1em;vertical-align: sub; color: #3176d9">
+      <g>
+        <path d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z" />
+      </g>
+    </svg>
+    <a class="github-link" title="Edit this page" href="" target="_blank">
+      <span id="edit-github-text">Edit this page</span>
+    </a>
+  </div>
+  {{ end }}
+</div>
+<script>
+  let reg = /\/docs\/[a-zA-Z\-]+\/([\w|\.]+)\//;
+  let res = reg.exec(location.href);
+  let version = res && res[1];
+  let editGithub = document.getElementById("edit-github");
+  if (editGithub) {
+    editGithub.style.display = version === "next" ? "block" : "none";
+  }
+  
+  if (version === "next") {
+    reg = /\/docs\/(.+?)\//;
+    let repoRes = reg.exec(location.href);
+    let repo = repoRes && repoRes[1];
+    if (repo === "main") {
+      repo = "skywalking"
+    }
+    reg = /\/next\/(.+)/;
+    let docs = reg.exec(location.href);
+    let docsUrl = docs && docs[1];
+    if (docsUrl) {
+      docsUrl = docsUrl.replace(/readme/i, 'README');
+    }
+    let prefixUrl = "https://github.com/apache/" + repo + "/blob/master/docs/";
+    let editGithubLink = document.querySelector("#edit-github a");
+    if (editGithubLink) {
+      editGithubLink.href = prefixUrl + docsUrl.replace(/\/$/, ".md");
+    }
+  }
+</script>

--- a/themes/docsy/layouts/projectDoc/content.html
+++ b/themes/docsy/layouts/projectDoc/content.html
@@ -1,28 +1,3 @@
 <div class="td-content">
-<!--	<h1>{{ .Title }}</h1>-->
-<!--	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}-->
-<!--	<div class="td-byline mb-4">-->
-<!--		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}-->
-<!--		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>-->
-
-
-<!--		{{ with .Params.tags }}-->
-<!--		<p class="mt-1 tags-box">-->
-<!--			<i class="fas fa-tags" aria-hidden="true"></i>Tags |-->
-<!--			{{ range . }}-->
-<!--			<span> <a href="{{ "tags" | absURL }}/{{ . | urlize }}">{{ . }}</a></span>-->
-<!--			{{ end }}-->
-<!--		</p>-->
-<!--		{{ end }}-->
-
-
-<!--	</div>-->
 	{{ .Content }}
-<!--	{{ if (.Site.DisqusShortname) }}-->
-<!--		<br />-->
-<!--		{{ partial "disqus-comment.html" . }}-->
-<!--		<br />-->
-<!--	{{ end }}-->
-
-<!--	{{ partial "pager.html" . }}-->
 </div>

--- a/themes/docsy/layouts/projectDoc/single.html
+++ b/themes/docsy/layouts/projectDoc/single.html
@@ -1,3 +1,4 @@
 {{ define "main" }}
 {{ .Render "content" }}
+{{ partial "edit-this-page.html" . }}
 {{ end }}


### PR DESCRIPTION
### Summary

**why**
In order to allow users to edit the document more directly and quickly, a link to the corresponding resource has been added to the document.

**what**
The scope of changes is only for project documents, and the version is `next`.
<img width="1200" alt="image" src="https://github.com/apache/skywalking-website/assets/66550292/ceab9a4d-386e-4373-9577-f491119cebdb">

**how**
Due to the need to adapt to multiple sub-projects, there is no link to the edit page because not all projects’ default branches are master, such as [origin-development-guide](https://skywalking.apache.org/docs/skywalking-go/next/en/development-and-contribution/development-guide/) will jump to [development-guide.md](https://github.com/apache/skywalking-go/blob/main/docs/en/development-and-contribution/development-guide.md)
