### PR TITLE
Add SkyWalking GraalVM Distro 0.3.0 release

### DIFF
--- a/content/events/release-apache-skywalking-graalvm-distro-0.3.0/index.md
+++ b/content/events/release-apache-skywalking-graalvm-distro-0.3.0/index.md
@@ -1,0 +1,42 @@
+---
+title: Release Apache SkyWalking GraalVM Distro version 0.3.0
+date: 2026-04-10
+author: SkyWalking Team
+description: "Release Apache SkyWalking GraalVM Distro 0.3.0"
+endTime: 2026-06-10T00:00:00Z
+---
+
+SkyWalking GraalVM Distro 0.3.0 is released. Go to [downloads](https://skywalking.apache.org/downloads/#SkyWalkingGraalVMDistro) page to find release tars.
+
+
+### Upstream Sync
+
+- Sync SkyWalking submodule to upstream v10.4.0 release tag.
+- Add `gen-ai-analyzer` module: GenAI provider/model metrics from virtual-gen-ai.oal.
+- Add Envoy AI Gateway MAL/LAL rules and config.
+- Add TraceQL config properties: `lookback`, `zipkinTracesListResultTags`, `skywalkingTracesListResultTags`.
+
+### GraalVM Native Image Compatibility
+
+- Add `library-server-for-graalvm`: replace `DynamicSslContext` to use `SslProvider.JDK` instead of `SslProvider.OPENSSL`, enabling gRPC TLS in native images without `netty_tcnative`.
+
+### Documentation
+
+- Document TLS/SSL limitation: native image lacks `netty_tcnative`, recommend service mesh for mTLS.
+
+### E2E Tests
+
+- Add SSL e2e test case (gRPC TLS with JDK SSL provider in native image).
+- Add mTLS e2e test case (mutual TLS with client certificates).
+- Add RabbitMQ, RocketMQ, ActiveMQ, Pulsar, Kafka, Redis, MongoDB, Flink monitoring e2e test cases (OTEL metrics collection).
+- Add AWS DynamoDB, S3, EKS, API Gateway e2e test cases (mock sender metrics).
+- Add Auth e2e test case (token-based agent-to-OAP authentication).
+- Add OTLP Traces e2e test case (OpenTelemetry trace ingestion via Zipkin API).
+- Add Virtual MQ e2e test case (Kafka-instrumented virtual MQ layer metrics).
+- Add Kafka Exporter e2e test case (trace and log export to Kafka).
+- Add Virtual GenAI e2e test case (GenAI provider/model metrics via Spring AI + Java agent).
+- Add Envoy AI Gateway e2e test case (ENVOY_AI_GATEWAY layer metrics/logs via OTLP).
+- Add TraceQL SkyWalking e2e test case (Tempo API with SkyWalking native trace datasource).
+- Add Envoy AI Gateway MAL comparison tests (34 tests for gateway-service and gateway-instance rules).
+- Add Self-Observability e2e test case (OAP Prometheus telemetry via OTEL collector).
+- Add MQE e2e test case (Metrics Query Engine expression evaluation with baseline).

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -78,7 +78,10 @@
           link: /docs/skywalking-graalvm-distro/next/readme/
         - version: Latest
           link: /docs/skywalking-graalvm-distro/latest/readme/
-          commitId: 5487ed31653fe7a573b0467ae2c4c365204ade5d  
+          commitId: 1ab407eb25e2f0ef90f74fd252f277bca9b52910
+        - version: 0.3.0
+          link: /docs/skywalking-graalvm-distro/v0.3.0/readme/
+          commitId: 1ab407eb25e2f0ef90f74fd252f277bca9b52910
         - version: v0.2.1 (10.3.0-dev-64a1795)
           link: /docs/skywalking-graalvm-distro/v0.2.1/readme/
           commitId: 5487ed31653fe7a573b0467ae2c4c365204ade5d

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -190,39 +190,71 @@
       icon: skywalking
       description: A re-distribution of the Apache SkyWalking OAP server based on GraalVM native image. This is experimental.
       source:
+        - version: 0.3.0
+          date: Apr. 10th, 2026
+          downloadLink:
+            - name: src
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz.sha512
         - version: 0.2.1 (10.3.0-dev-64a1795)
           date: Mar. 23rd, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz.sha512
       distribution:
+        - version: 0.3.0
+          date: Apr. 10th, 2026
+          downloadLink:
+            - name: Linux AMD64
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz.sha512
+            - name: "|"
+            - name: Linux ARM64
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz.sha512
+            - name: "|"
+            - name: MacOS ARM
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz.sha512
         - version: 0.2.1 (10.3.0-dev-64a1795)
           date: Mar. 23rd, 2026
           downloadLink:
             - name: Linux AMD64
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz.sha512
             - name: "|"
             - name: Linux ARM64
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz.sha512
             - name: "|"
             - name: MacOS ARM
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz.sha512
     - name: Booster UI
       icon: rocketbot-ui
       description: SkyWalking's primary UI. All source codes have been included in the main repo release.


### PR DESCRIPTION
## Summary

- Update `data/releases.yml`: add 0.3.0 download links (closer.cgi), migrate previous version URLs to archive.apache.org
- Update `data/docs.yml`: add 0.3.0 documentation version, update Latest commitId
- Add release event post for 0.3.0

Release notes: https://github.com/apache/skywalking-graalvm-distro/blob/v0.3.0/changes/changes.md