### PR TITLE
Release Apache SkyWalking BanyanDB 0.10.2

### DIFF
--- a/content/events/release-apache-skywalking-banyandb-0-10-2/index.md
+++ b/content/events/release-apache-skywalking-banyandb-0-10-2/index.md
@@ -1,0 +1,38 @@
+---
+title: Release Apache SkyWalking BanyanDB 0.10.2
+date: 2026-05-06
+author: SkyWalking Team
+---
+
+SkyWalking BanyanDB 0.10.2 is released. Go to [downloads](/downloads) page to find release tars.
+
+### Bug Fixes
+
+- Fix reuse of byte arrays in min/max implementation causing data corruption.
+- Fix index-mode measure queries returning documents outside requested time range.
+- Fix nil pointer panic in segment collectMetrics during shutdown.
+- Fix property schema client connection instability after data node restart.
+- Fix take snapshot error when no data in the segment.
+- Fix(storage): disable rotation task on warm and cold lifecycle nodes.
+- Fix(storage): prevent epoch segment creation from zero timestamps.
+- Fix(sidx): use MinTimestamp/MaxTimestamp instead of SegmentID in streaming sync.
+- Fix(handoff): prevent size limit bypass and sidx timestamp corruption in handoff replay.
+- Fix(handoff): prevent enqueuing parts for online nodes via shared LocateAll.
+- Fix wrong backup path of schema property.
+- Fix OOM issue during migration when a group contains a large amount of data.
+- Fix lifecycle migration failure when the target stage has `close: true`.
+- Fix stale sync request blocking watch session channel.
+- Fix nil pointer panic in disk monitor during early initialization.
+- Fix FileSystemError not matching io/fs.ErrNotExist sentinel.
+- Fix(topn): deduplicate entities in TopN aggregation query.
+- Fix(stream): skip element-index visit when idx/ is absent.
+- Fix(metadata): widen FODC inspection broadcast deadline and parallelize InspectAll.
+- Fix(measure,stream,trace): eliminate flusher/introducer data race on shutdown.
+- Fix: use `topic` instead of `session_id` as the Prometheus label.
+- Fix(fodc): heal reconnect deadlock and add error message when no agents for lifecycle request.
+- Fix(MCP): add explicit validation for properties and tools, and harden the server.
+
+### Chores
+
+- Upgrade Go and npm dependencies for CVE fixes.
+- Bump ui and mcp npm dependencies for CVE fixes.

--- a/content/quickstart-docker.sh
+++ b/content/quickstart-docker.sh
@@ -20,8 +20,8 @@ set -e
 
 SW_STORAGE=
 
-SW_VERSION=${SW_VERSION:-10.3.0}
-SW_BANYANDB_VERSION=${SW_BANYANDB_VERSION:-0.9.0}
+SW_VERSION=${SW_VERSION:-10.4.0}
+SW_BANYANDB_VERSION=${SW_BANYANDB_VERSION:-0.10.2}
 
 usage() {
   echo "Usage: quickstart-docker.sh [-f]"
@@ -54,6 +54,10 @@ fi
 temp_dir=$(mktemp -d)
 
 curl -fsSL https://github.com/apache/skywalking/raw/master/docker/docker-compose.yml -o "$temp_dir/docker-compose.yml"
+
+# Patch OAP health check for SkyWalking 10.4.0+ (curl not available in image)
+perl -pi -e "s|curl http://localhost:12800/internal/l7check|bash -c 'echo >/dev/tcp/localhost/12800'|" "$temp_dir/docker-compose.yml"
+sed -i 's|start_period: 10s|start_period: 120s|g' "$temp_dir/docker-compose.yml"
 
 # If SW_STORAGE is not set, prompt the user to select a storage option
 if [ -z "$SW_STORAGE" ]; then

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -360,9 +360,9 @@
         - version: Latest
           link: /docs/skywalking-banyandb/latest/readme/
           commitId: dda5b5edfda8d90996f37fcb713d8b1035739dd4
-        - version: v0.10.1
-          link: /docs/skywalking-banyandb/v0.10.1/readme/
-          commitId: dda5b5edfda8d90996f37fcb713d8b1035739dd4
+        - version: v0.10.2
+          link: /docs/skywalking-banyandb/v0.10.2/readme/
+          commitId: 55c6007c2fde1637a53deac1a6dfd27e987ba4db
     - name: BanyanDB Client Proto
       icon: banyan-db
       description: Protocol definitions in Protobuf/gRPC for BanyanDB clients

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -752,48 +752,48 @@
       icon: banyan-db
       description: The BanyanDB Server
       source:
-        - version: v0.10.1
-          date: Apr. 6th, 2026
+        - version: v0.10.2
+          date: May. 6th, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-src.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-src.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-src.tgz.asc
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-src.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-src.tgz.sha512
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-src.tgz.sha512
       distribution:
-        - version: v0.10.1
-          date: Apr. 6th, 2026
+        - version: v0.10.2
+          date: May. 6th, 2026
           downloadLink:
             - name: tar
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-banyand.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-banyand.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-banyand.tgz.asc
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-banyand.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-banyand.tgz.sha512
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-banyand.tgz.sha512
     - name: BanyanDB Command Line Tool(bydbctl)
       icon: banyan-db
       description: The BanyanDB Command Line Tool, which provides the ability to manage BanyanDB.
       source:
-        - version: v0.10.1
-          date: Apr. 6th, 2026
+        - version: v0.10.2
+          date: May. 6th, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-src.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-src.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-src.tgz.asc
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-src.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-src.tgz.sha512
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-src.tgz.sha512
       distribution:
-        - version: v0.10.1
-          date: Apr. 6th, 2026
+        - version: v0.10.2
+          date: May. 6th, 2026
           downloadLink:
             - name: tar
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-bydbctl.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-bydbctl.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-bydbctl.tgz.asc
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-bydbctl.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/banyandb/0.10.1/skywalking-banyandb-0.10.1-bydbctl.tgz.sha512
+              link: https://downloads.apache.org/skywalking/banyandb/0.10.2/skywalking-banyandb-0.10.2-bydbctl.tgz.sha512
     - name: BanyanDB Java Client
       icon: banyan-db
       description: The client implementation for SkyWalking BanyanDB in Java


### PR DESCRIPTION
## Summary
- Update downloads, docs, and release links to BanyanDB v0.10.2
- Add release event page for BanyanDB 0.10.2
- Update quickstart script: SW 10.4.0, BanyanDB 0.10.2, fix OAP health check

## Test plan
- [x] Quickstart-docker.sh tested with all containers healthy (banyandb, oap, ui)
- [x] BanyanDB web UI accessible on port 17913
- [x] Download links point to correct 0.10.2 artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)