### PR TITLE
Release swck 0.10.0

### DIFF
--- a/content/events/release-apache-skywalking-cloud-on-kubernetes-0-10-0/index.md
+++ b/content/events/release-apache-skywalking-cloud-on-kubernetes-0-10-0/index.md
@@ -1,0 +1,18 @@
+---
+title: Release Apache SkyWalking Cloud on Kubernetes 0.10.0
+date: 2026-06-02
+author: SkyWalking Team
+description: "Release Apache SkyWalking Cloud on Kubernetes 0.10.0"
+---
+
+SkyWalking Cloud on Kubernetes 0.10.0 is released. Go to [downloads](https://skywalking.apache.org/downloads) page to find release tars.
+
+0.10.0
+------------------
+
+### Features
+- Add the CRD and Controller for the SkyWalking Event Exporter.
+- Support Horizon UI in the UI CRD via the `spec.kind` discriminator.
+
+### Documentation
+- Add documentation for the Event Exporter.

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -330,10 +330,10 @@
           link: /docs/skywalking-swck/next/readme/
         - version: Latest
           link: /docs/skywalking-swck/latest/readme/
-          commitId: 502610b1cc71940cb36107ec335bd47aa829a781
-        - version: v0.9.0
-          link: /docs/skywalking-swck/v0.9.0/readme/
-          commitId: 77a22047a37e974b7a12535f9d3b7667261c3a7a
+          commitId: d299bc05ee230f5f366584054db5b099ca60166f
+        - version: v0.10.0
+          link: /docs/skywalking-swck/v0.10.0/readme/
+          commitId: d299bc05ee230f5f366584054db5b099ca60166f
 - type: Protocol
   description:
   list:

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -741,25 +741,25 @@
       icon: kubernetes
       description: A bridge project between Apache SkyWalking and Kubernetes.
       source:
-        - version: v0.9.0
-          date: Mar. 4th, 2024
+        - version: v0.10.0
+          date: Jun. 2nd, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/swck/0.9.0/skywalking-swck-0.9.0-src.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/swck/0.10.0/skywalking-swck-0.10.0-src.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/swck/0.9.0/skywalking-swck-0.9.0-src.tgz.asc
+              link: https://downloads.apache.org/skywalking/swck/0.10.0/skywalking-swck-0.10.0-src.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/swck/0.9.0/skywalking-swck-0.9.0-src.tgz.sha512
+              link: https://downloads.apache.org/skywalking/swck/0.10.0/skywalking-swck-0.10.0-src.tgz.sha512
       distribution:
-        - version: v0.9.0
-          date: Mar. 4th, 2024
+        - version: v0.10.0
+          date: Jun. 2nd, 2026
           downloadLink:
             - name: tar
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/swck/0.9.0/skywalking-swck-0.9.0-bin.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/swck/0.10.0/skywalking-swck-0.10.0-bin.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/swck/0.9.0/skywalking-swck-0.9.0-bin.tgz.asc
+              link: https://downloads.apache.org/skywalking/swck/0.10.0/skywalking-swck-0.10.0-bin.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/swck/0.9.0/skywalking-swck-0.9.0-bin.tgz.sha512
+              link: https://downloads.apache.org/skywalking/swck/0.10.0/skywalking-swck-0.10.0-bin.tgz.sha512
 - type: Database
   description:
   list:


### PR DESCRIPTION
Add the release event/news post and data updates for Apache SkyWalking Cloud on Kubernetes (SWCK) 0.10.0.

## Changes
- **Event post**: `content/events/release-apache-skywalking-cloud-on-kubernetes-0-10-0/index.md` with the user-facing changes (Event Exporter CRD/Controller, Horizon UI support in the UI CRD, Event Exporter docs). Dependency/CVE bumps excluded.
- **data/releases.yml**: replace v0.9.0 with v0.10.0 (closer.cgi for download, downloads.apache.org for asc/sha512).
- **data/docs.yml**: bump `Latest` commitId, add a `v0.10.0` docs entry, keep `v0.9.0`.

Source: https://github.com/apache/skywalking-swck/releases/tag/v0.10.0 (tag commit `d299bc05ee230f5f366584054db5b099ca60166f`).