### PR TITLE
Blog: align Horizon UI intro title to the series convention (1/16)

### DIFF
--- a/content/blog/2026-06-21-skywalking-horizon-ui-introduction/index.md
+++ b/content/blog/2026-06-21-skywalking-horizon-ui-introduction/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI: SkyWalking's New Observability Console"
+title: "Meet Horizon UI · 1/16: SkyWalking's New Observability Console"
 date: 2026-06-21
 author: Sheng Wu
 description: "Introducing Apache SkyWalking Horizon UI — the next-generation web UI. A greenfield rewrite on the same OAP backend that you can observe, operate, govern, and customize, starting with a sidebar that mirrors your whole estate."


### PR DESCRIPTION
Adds the `Horizon UI (N/16):` series prefix + sequence to the introduction post (#855) so the series connects in blog listings. Title-only; slug/URL unchanged. Matches the same convention applied to part 2 in #856.