### PR TITLE
Blog index: 3 posts per row via a topic dropdown filter

### DIFF
--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -1322,7 +1322,10 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   padding: 12px 10px 24px;
 
   .nav-links { padding: 0; }
-  .nav-links .nav-item, .nav-links .repo-link { border: 0; margin: 0; }
+  // `font-family: inherit` neutralizes the theme's stale `Lato` (dropped with
+  // Google Fonts) so the drawer uses the site's system font stack, not the
+  // generic sans-serif fallback.
+  .nav-links .nav-item, .nav-links .repo-link { border: 0; margin: 0; font-family: inherit; }
 
   // top-level links
   .nav-links a.nav-link {

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -791,8 +791,8 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   .blog-year {
     font-size: 12px; font-weight: 700; color: $muted; border: 0; padding: 0;
     margin: 28px 0 12px; letter-spacing: .1em; text-transform: uppercase;
-    // The very first year heading in the main column must align with the
-    // sidebar's "Browse topics" heading on the same grid row.
+    // Tighten the first year heading's top margin — it now sits just below the
+    // Browse-topics topbar (no sidebar to align a shared grid row to).
     &:first-child { margin-top: 4px; }
   }
 
@@ -860,7 +860,6 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   // ── Full-width post grid + a "Browse topics" dropdown filter ──────────
   // The post grid stays 3-up (its base rule above) because the topic list
   // now lives in a dropdown instead of a 300px sidebar, freeing the width.
-  .blog-content { min-width: 0; }   // prevent grid blowout from wide cards
   .blog-topbar { display: flex; justify-content: flex-end; margin: 0 0 18px; }
   .topic-filter { position: relative; }
   .topic-filter-btn {
@@ -881,25 +880,49 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   .topic-filter[open] .topic-filter-caret { transform: rotate(180deg); }
   .topic-filter-menu {
     position: absolute; right: 0; top: calc(100% + 8px); z-index: 30;
-    width: 280px; max-height: 64vh; overflow-y: auto;
+    width: 580px; max-width: calc(100vw - 32px); max-height: 72vh; overflow-y: auto;
     background: #fff; border: 1px solid $line; border-radius: 12px;
     box-shadow: 0 24px 48px -24px rgba(17, 24, 39, .30);
-    padding: 6px;
+    padding: 8px;
   }
-  .topic-filter-item {
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 10px; padding: 8px 10px; border-radius: 8px; text-decoration: none;
-    transition: background .12s ease;
-    .blog-label { text-decoration: none; }
+  // Full-width "All posts" reset row above the two-column topic grid.
+  .topic-filter-all {
+    display: flex; align-items: center; justify-content: space-between; gap: 10px;
+    padding: 9px 10px; border-radius: 8px; text-decoration: none;
+    font-size: 13.5px; font-weight: 700; color: $ink;
+    border-bottom: 1px solid $line; margin-bottom: 6px;
     &:hover { background: #f3f6fa; }
-    &.is-all {
-      font-weight: 700; color: $ink;
-      border-bottom: 1px solid $line; border-radius: 8px 8px 0 0; margin-bottom: 4px;
-    }
+  }
+  .topic-filter-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 6px;
+  }
+  // Each topic keeps its pill, count and one-line description ("the words").
+  .topic-filter-card {
+    display: flex; flex-direction: column; gap: 6px;
+    padding: 10px; border-radius: 9px; text-decoration: none;
+    transition: background .12s ease;
+    &:hover { background: #f3f6fa; }
+  }
+  .topic-filter-card-top {
+    display: flex; align-items: center; justify-content: space-between; gap: 8px;
+    .blog-label { text-decoration: none; min-width: 0; }
+    .album-count { flex: 0 0 auto; }
+  }
+  .topic-filter-card-intro {
+    font-size: 12px; color: $body; line-height: 1.5;
+    display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+  }
+  // Keyboard focus ring. The Docsy reboot sets `a { outline: none }`, which
+  // would otherwise leave these link cards / buttons with no visible focus.
+  .topic-filter-btn:focus-visible,
+  .topic-filter-all:focus-visible,
+  .topic-filter-card:focus-visible {
+    outline: 2px solid rgba(55, 136, 208, .7);
+    outline-offset: 2px;
   }
   // The per-topic count pill, reused in the dropdown rows.
   .album-count {
-    font-size: 11px; font-weight: 800; color: $muted; letter-spacing: .04em;
+    font-size: 11px; font-weight: 800; color: #5b6573; letter-spacing: .04em;
     padding: 1px 7px; border-radius: 999px;
     background: #f3f6fa; border: 1px solid $line;
   }
@@ -980,14 +1003,20 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
 @media (max-width: 992px) {
   .td-blog .blog-grid { grid-template-columns: 1fr 1fr; }
 }
+// Collapse the two-column topic dropdown to one full-width column early, so the
+// ~600–760px band gets a clean single column instead of a 580px panel almost as
+// wide as the viewport.
+@media (max-width: 760px) {
+  .td-blog .topic-filter-menu { width: 100%; }
+  .td-blog .topic-filter-grid { grid-template-columns: 1fr; }
+}
 @media (max-width: 600px) {
   .td-blog .blog-grid { grid-template-columns: 1fr; }
   .td-blog .blog-hero { padding-top: calc(4rem + 18px); h1 { font-size: 30px; } }
-  // Let the topic dropdown go full-width so its menu never overflows.
+  // Make the dropdown trigger button full-width too on phones.
   .td-blog .blog-topbar { justify-content: stretch; }
   .td-blog .topic-filter { width: 100%; }
   .td-blog .topic-filter-btn { width: 100%; justify-content: space-between; }
-  .td-blog .topic-filter-menu { width: 100%; }
 }
 
 // =====================================================================

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -857,56 +857,51 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     .page-item.active .page-link { background: $brand; border-color: $brand; color: #fff !important; }
   }
 
-  // ── Two-column layout: main posts + right "Browse topics" sidebar ─────
-  .blog-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 300px;
-    gap: 36px;
-    align-items: start;
-  }
+  // ── Full-width post grid + a "Browse topics" dropdown filter ──────────
+  // The post grid stays 3-up (its base rule above) because the topic list
+  // now lives in a dropdown instead of a 300px sidebar, freeing the width.
   .blog-content { min-width: 0; }   // prevent grid blowout from wide cards
-  .blog-sidebar { position: relative; }
-  // No internal scroll: the sidebar just scrolls with the page. (Sticky here
-  // doesn't behave usefully — align-items: start sizes the grid cell to the
-  // sidebar's own height, so there's nothing to stick to.)
-  .blog-sidebar-inner { padding-right: 2px; }
-  // Same font/weight/spacing as .blog-year so both column heads visually
-  // align on the first row of .blog-layout.
-  .blog-sidebar-head {
-    font-size: 12px; font-weight: 700; letter-spacing: .1em;
-    text-transform: uppercase; color: $muted;
-    margin: 4px 0 12px; border: 0; padding: 0;
+  .blog-topbar { display: flex; justify-content: flex-end; margin: 0 0 18px; }
+  .topic-filter { position: relative; }
+  .topic-filter-btn {
+    list-style: none; cursor: pointer; user-select: none;
+    display: inline-flex; align-items: center; gap: 8px;
+    height: 38px; padding: 0 14px;
+    background: #fff; border: 1px solid $line; border-radius: 10px;
+    font-size: 13px; font-weight: 600; color: $ink;
+    transition: border-color .15s ease, box-shadow .15s ease;
+    &::-webkit-details-marker { display: none; }
+    &::marker { content: ""; }
+    &:hover { border-color: #d6e4f5; }
   }
-  // With sidebar present the main grid should be 2 cols to keep cards readable
-  .blog-grid { grid-template-columns: 1fr 1fr; }
-
-  // ── "Album" topic cards — used inside the sidebar ─────────────────────
-  .album-grid {
-    display: grid; grid-template-columns: 1fr; gap: 10px;
+  .topic-filter[open] .topic-filter-btn {
+    border-color: #d6e4f5; box-shadow: 0 0 0 3px rgba(44, 108, 176, .10);
   }
-  .album-card {
-    display: flex; flex-direction: column;
+  .topic-filter-caret { flex: 0 0 auto; transition: transform .18s ease; }
+  .topic-filter[open] .topic-filter-caret { transform: rotate(180deg); }
+  .topic-filter-menu {
+    position: absolute; right: 0; top: calc(100% + 8px); z-index: 30;
+    width: 280px; max-height: 64vh; overflow-y: auto;
     background: #fff; border: 1px solid $line; border-radius: 12px;
-    padding: 12px 14px; text-decoration: none;
-    transition: box-shadow .18s ease, border-color .18s ease, transform .18s ease;
-    &:hover {
-      box-shadow: 0 12px 28px -16px rgba(17,24,39,.22);
-      border-color: #d6e4f5; transform: translateY(-1px);
+    box-shadow: 0 24px 48px -24px rgba(17, 24, 39, .30);
+    padding: 6px;
+  }
+  .topic-filter-item {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; padding: 8px 10px; border-radius: 8px; text-decoration: none;
+    transition: background .12s ease;
+    .blog-label { text-decoration: none; }
+    &:hover { background: #f3f6fa; }
+    &.is-all {
+      font-weight: 700; color: $ink;
+      border-bottom: 1px solid $line; border-radius: 8px 8px 0 0; margin-bottom: 4px;
     }
   }
-  .album-top {
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 8px; margin-bottom: 8px;
-  }
+  // The per-topic count pill, reused in the dropdown rows.
   .album-count {
     font-size: 11px; font-weight: 800; color: $muted; letter-spacing: .04em;
     padding: 1px 7px; border-radius: 999px;
     background: #f3f6fa; border: 1px solid $line;
-  }
-  .album-intro {
-    font-size: 12.5px; color: $body; line-height: 1.5;
-    margin: 0;
-    display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
   }
 
   // ── Tag term page hero ─────────────────────────────────────────────────
@@ -981,22 +976,18 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   }
 }
 
-// Below 992px stack the sidebar above the post grid; topic cards become a
-// horizontal-scroll row so they don't dominate the viewport.
+// Step the post grid down on narrower viewports (3 → 2 → 1 columns).
 @media (max-width: 992px) {
-  .td-blog .blog-layout { grid-template-columns: 1fr; gap: 24px; }
-  .td-blog .blog-sidebar { order: -1; }
-  .td-blog .blog-sidebar-inner { position: static; max-height: none; overflow: visible; }
-  .td-blog .album-grid {
-    display: flex; gap: 10px; overflow-x: auto;
-    padding-bottom: 6px; scroll-snap-type: x mandatory;
-  }
-  .td-blog .album-card { flex: 0 0 240px; scroll-snap-align: start; }
   .td-blog .blog-grid { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 600px) {
   .td-blog .blog-grid { grid-template-columns: 1fr; }
   .td-blog .blog-hero { padding-top: calc(4rem + 18px); h1 { font-size: 30px; } }
+  // Let the topic dropdown go full-width so its menu never overflows.
+  .td-blog .blog-topbar { justify-content: stretch; }
+  .td-blog .topic-filter { width: 100%; }
+  .td-blog .topic-filter-btn { width: 100%; justify-content: space-between; }
+  .td-blog .topic-filter-menu { width: 100%; }
 }
 
 // =====================================================================

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -1334,12 +1334,15 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
 
   // dropdown groups (中文资料 / Links)
   .dropdown-wrapper { margin-top: 4px; }
+  // The dropdown groups (中文资料 / Links) are top-level menu entries too, so
+  // match the .nav-link items above instead of rendering as tiny gray uppercase
+  // section labels — keeps the drawer's font style consistent.
   .dropdown-wrapper .dropdown-title {
     display: flex; align-items: center; justify-content: space-between;
     padding: 10px 14px; border-radius: 9px;
-    color: #8a93a3; font-weight: 700; font-size: 11px; letter-spacing: .08em; text-transform: uppercase;
+    color: #4b5563; font-weight: 600; font-size: 15px; line-height: 1.3;
     cursor: pointer;
-    &:hover { background: #f4f7fb; color: #4b5563; }
+    &:hover { background: #eef5fd; color: #1F1F20; }
   }
   .dropdown-wrapper .nav-dropdown { margin: 2px 0 8px; padding: 0; list-style: none; }
   .dropdown-wrapper .nav-dropdown .dropdown-item a {
@@ -1349,6 +1352,21 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   }
   // hide the little caret arrows; the groups read fine as labels
   .dropdown-wrapper .dropdown-title .arrow { display: none; }
+}
+
+// ── Mobile gutter for the custom full-bleed landing pages ─────────────────────
+// These pages drop content straight into a <section> > .container with no
+// Bootstrap .col to supply a gutter, and the theme zeroes .container padding
+// globally — so on small screens the content sits flush against the viewport
+// edge. Page-scoped so it outranks the theme's bare `.container { padding: 0 }`
+// without touching the theme; the blog/article pages keep their .col gutter.
+@media (max-width: 991.98px) {
+  .td-home .container,
+  .td-docs-landing .container,
+  .td-events .container,
+  .td-downloads .container,
+  .td-team .container,
+  .td-users .container { padding-left: 20px; padding-right: 20px; }
 }
 
 // ── Permalink "hook" on project cards (docs landing + downloads) ──────────────

--- a/data/blog_topics.yml
+++ b/data/blog_topics.yml
@@ -1,7 +1,7 @@
 # Single source of truth for blog topics (a.k.a. "tags").
 #
 # Used by:
-#   - layouts/blog/list.html  + layouts/zh/list.html     — sidebar topic cards
+#   - layouts/blog/list.html  + layouts/zh/list.html     — Browse-topics dropdown cards
 #   - layouts/partials/blog-topic-styles.html            — generates the
 #                                                          .blog-label[data-label="X"]
 #                                                          color rules at build time
@@ -11,8 +11,8 @@
 #
 # Field reference:
 #   name      Canonical tag string. Match exactly in post frontmatter `tags:`.
-#   intro     One-line EN description, shown on /blog/ sidebar topic card.
-#   intro_zh  CN counterpart, shown on /zh/ sidebar topic card.
+#   intro     One-line EN description, shown on the /blog/ Browse-topics dropdown card.
+#   intro_zh  CN counterpart, shown on the /zh/ Browse-topics dropdown card.
 #   color     bg/fg/border for the colored pill. Bg should be a light tint,
 #             fg the accessible darker text/icon color, border the same hue
 #             slightly deeper than bg.

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -7,12 +7,6 @@
 {{ $pages := ($.Scratch.Get "blog-pages") }}
 {{ $groups := $pages.GroupByDate (i18n "year") }}
 
-{{- /* Tag list derived only from blog posts (Site.Taxonomies.tags would
-       also include docs frontmatter, which is unrelated). */ -}}
-{{ $allTags := slice }}
-{{ range $pages }}{{ range .Params.tags }}{{ $allTags = $allTags | append . }}{{ end }}{{ end }}
-{{ $blogTags := sort (uniq $allTags) }}
-
 {{- /* Topics (name + intro + color) are defined in data/blog_topics.yml. */ -}}
 {{ $topics := .Site.Data.blog_topics.topics }}
 
@@ -35,20 +29,25 @@
         <svg class="topic-filter-caret" width="13" height="13" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </summary>
       <div class="topic-filter-menu">
-        <a class="topic-filter-item is-all" href="{{ "/blog/" | relLangURL }}">
-          <span class="topic-filter-all">All posts</span>
+        <a class="topic-filter-all" href="{{ "/blog/" | relLangURL }}">
+          <span>All posts</span>
           <span class="album-count">{{ len $pages }}</span>
         </a>
-        {{ range $topics }}
-        {{ $t := .name }}
-        {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
-        {{ if gt (len $tagged) 0 }}
-        <a class="topic-filter-item" data-label="{{ $t }}" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
-          <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
-          <span class="album-count">{{ len $tagged }}</span>
-        </a>
-        {{ end }}
-        {{ end }}
+        <div class="topic-filter-grid">
+          {{ range $topics }}
+          {{ $t := .name }}
+          {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
+          {{ if gt (len $tagged) 0 }}
+          <a class="topic-filter-card" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
+            <span class="topic-filter-card-top">
+              <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
+              <span class="album-count">{{ len $tagged }}</span>
+            </span>
+            <span class="topic-filter-card-intro">{{ .intro }}</span>
+          </a>
+          {{ end }}
+          {{ end }}
+        </div>
       </div>
     </details>
   </div>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -25,52 +25,55 @@
 </section>
 
 <div class="container blog-wrap">
-  <div class="blog-layout">
-    <div class="blog-content">
-      {{ range $groups }}
-      <h2 class="blog-year">{{ T "post_posts_in" }} {{ .Key }}</h2>
-      <div class="blog-grid">
-        {{ range .Pages }}
-        <article class="blog-card">
-          {{ with .Params.tags }}
-          <div class="blog-labels">
-            {{ range . }}<a class="blog-label" data-label="{{ . }}" href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>{{ end }}
-          </div>
-          {{ end }}
-          <h3 class="blog-card-title"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h3>
-          <p class="blog-card-preview">{{ with .Description }}{{ . }}{{ else }}{{ .Plain | safeHTML | truncate 160 }}{{ end }}</p>
-          <div class="blog-card-foot">
-            <span class="blog-date">{{ .Date.Format "Jan 2, 2006" }}</span>
-            {{ with .Params.author }}<span class="blog-author">{{ . | markdownify }}</span>{{ end }}
-          </div>
-        </article>
+  {{- /* Topic filter: a dropdown of the canonical tags (data/blog_topics.yml),
+         each linking to its /tags/<term>/ page. Replaces the old right sidebar
+         so the post grid gets the full width (3-up). */ -}}
+  <div class="blog-topbar">
+    <details class="topic-filter">
+      <summary class="topic-filter-btn">
+        <span>Browse topics</span>
+        <svg class="topic-filter-caret" width="13" height="13" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </summary>
+      <div class="topic-filter-menu">
+        <a class="topic-filter-item is-all" href="{{ "/blog/" | relLangURL }}">
+          <span class="topic-filter-all">All posts</span>
+          <span class="album-count">{{ len $pages }}</span>
+        </a>
+        {{ range $topics }}
+        {{ $t := .name }}
+        {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
+        {{ if gt (len $tagged) 0 }}
+        <a class="topic-filter-item" data-label="{{ $t }}" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
+          <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
+          <span class="album-count">{{ len $tagged }}</span>
+        </a>
+        {{ end }}
         {{ end }}
       </div>
+    </details>
+  </div>
+
+  <div class="blog-content">
+    {{ range $groups }}
+    <h2 class="blog-year">{{ T "post_posts_in" }} {{ .Key }}</h2>
+    <div class="blog-grid">
+      {{ range .Pages }}
+      <article class="blog-card">
+        {{ with .Params.tags }}
+        <div class="blog-labels">
+          {{ range . }}<a class="blog-label" data-label="{{ . }}" href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>{{ end }}
+        </div>
+        {{ end }}
+        <h3 class="blog-card-title"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h3>
+        <p class="blog-card-preview">{{ with .Description }}{{ . }}{{ else }}{{ .Plain | safeHTML | truncate 160 }}{{ end }}</p>
+        <div class="blog-card-foot">
+          <span class="blog-date">{{ .Date.Format "Jan 2, 2006" }}</span>
+          {{ with .Params.author }}<span class="blog-author">{{ . | markdownify }}</span>{{ end }}
+        </div>
+      </article>
       {{ end }}
     </div>
-
-    {{- /* Right sidebar: "Browse topics" — one compact card per canonical tag,
-           clicking opens /tags/<term>/. */ -}}
-    <aside class="blog-sidebar">
-      <div class="blog-sidebar-inner">
-        <h2 class="blog-sidebar-head">Browse topics</h2>
-        <div class="album-grid is-sidebar">
-          {{ range $topics }}
-          {{ $t := .name }}
-          {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
-          {{ if gt (len $tagged) 0 }}
-          <a class="album-card" data-label="{{ $t }}" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
-            <div class="album-top">
-              <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
-              <span class="album-count">{{ len $tagged }}</span>
-            </div>
-            <p class="album-intro">{{ .intro }}</p>
-          </a>
-          {{ end }}
-          {{ end }}
-        </div>
-      </div>
-    </aside>
+    {{ end }}
   </div>
 </div>
 {{ end }}

--- a/layouts/zh/list.html
+++ b/layouts/zh/list.html
@@ -22,50 +22,52 @@
 </section>
 
 <div class="container blog-wrap">
-  <div class="blog-layout">
-    <div class="blog-content">
-      {{ range $groups }}
-      <h2 class="blog-year">{{ .Key }} 年</h2>
-      <div class="blog-grid">
-        {{ range .Pages }}
-        <article class="blog-card">
-          {{ with .Params.tags }}
-          <div class="blog-labels">
-            {{ range . }}<a class="blog-label" data-label="{{ . }}" href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>{{ end }}
-          </div>
-          {{ end }}
-          <h3 class="blog-card-title"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h3>
-          <p class="blog-card-preview">{{ with .Description }}{{ . }}{{ else }}{{ .Plain | safeHTML | truncate 160 }}{{ end }}</p>
-          <div class="blog-card-foot">
-            <span class="blog-date">{{ .Date.Format "2006-01-02" }}</span>
-            {{ with .Params.author }}<span class="blog-author">{{ . | markdownify }}</span>{{ end }}
-          </div>
-        </article>
+  <div class="blog-topbar">
+    <details class="topic-filter">
+      <summary class="topic-filter-btn">
+        <span>按主题浏览</span>
+        <svg class="topic-filter-caret" width="13" height="13" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </summary>
+      <div class="topic-filter-menu">
+        <a class="topic-filter-item is-all" href="{{ "/zh/" | relLangURL }}">
+          <span class="topic-filter-all">全部文章</span>
+          <span class="album-count">{{ len $pages }}</span>
+        </a>
+        {{ range $topics }}
+        {{ $t := .name }}
+        {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
+        {{ if gt (len $tagged) 0 }}
+        <a class="topic-filter-item" data-label="{{ $t }}" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
+          <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
+          <span class="album-count">{{ len $tagged }}</span>
+        </a>
+        {{ end }}
         {{ end }}
       </div>
+    </details>
+  </div>
+
+  <div class="blog-content">
+    {{ range $groups }}
+    <h2 class="blog-year">{{ .Key }} 年</h2>
+    <div class="blog-grid">
+      {{ range .Pages }}
+      <article class="blog-card">
+        {{ with .Params.tags }}
+        <div class="blog-labels">
+          {{ range . }}<a class="blog-label" data-label="{{ . }}" href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>{{ end }}
+        </div>
+        {{ end }}
+        <h3 class="blog-card-title"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h3>
+        <p class="blog-card-preview">{{ with .Description }}{{ . }}{{ else }}{{ .Plain | safeHTML | truncate 160 }}{{ end }}</p>
+        <div class="blog-card-foot">
+          <span class="blog-date">{{ .Date.Format "2006-01-02" }}</span>
+          {{ with .Params.author }}<span class="blog-author">{{ . | markdownify }}</span>{{ end }}
+        </div>
+      </article>
       {{ end }}
     </div>
-
-    <aside class="blog-sidebar">
-      <div class="blog-sidebar-inner">
-        <h2 class="blog-sidebar-head">按主题浏览</h2>
-        <div class="album-grid is-sidebar">
-          {{ range $topics }}
-          {{ $t := .name }}
-          {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
-          {{ if gt (len $tagged) 0 }}
-          <a class="album-card" data-label="{{ $t }}" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
-            <div class="album-top">
-              <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
-              <span class="album-count">{{ len $tagged }}</span>
-            </div>
-            <p class="album-intro">{{ .intro_zh }}</p>
-          </a>
-          {{ end }}
-          {{ end }}
-        </div>
-      </div>
-    </aside>
+    {{ end }}
   </div>
 </div>
 {{ end }}

--- a/layouts/zh/list.html
+++ b/layouts/zh/list.html
@@ -7,10 +7,6 @@
 {{ $pages := ($.Scratch.Get "blog-pages") }}
 {{ $groups := $pages.GroupByDate (i18n "year") }}
 
-{{ $allTags := slice }}
-{{ range $pages }}{{ range .Params.tags }}{{ $allTags = $allTags | append . }}{{ end }}{{ end }}
-{{ $blogTags := sort (uniq $allTags) }}
-
 {{ $topics := .Site.Data.blog_topics.topics }}
 
 <section class="blog-hero">
@@ -29,20 +25,25 @@
         <svg class="topic-filter-caret" width="13" height="13" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </summary>
       <div class="topic-filter-menu">
-        <a class="topic-filter-item is-all" href="{{ "/zh/" | relLangURL }}">
-          <span class="topic-filter-all">全部文章</span>
+        <a class="topic-filter-all" href="{{ "/zh/" | relLangURL }}">
+          <span>全部文章</span>
           <span class="album-count">{{ len $pages }}</span>
         </a>
-        {{ range $topics }}
-        {{ $t := .name }}
-        {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
-        {{ if gt (len $tagged) 0 }}
-        <a class="topic-filter-item" data-label="{{ $t }}" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
-          <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
-          <span class="album-count">{{ len $tagged }}</span>
-        </a>
-        {{ end }}
-        {{ end }}
+        <div class="topic-filter-grid">
+          {{ range $topics }}
+          {{ $t := .name }}
+          {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
+          {{ if gt (len $tagged) 0 }}
+          <a class="topic-filter-card" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
+            <span class="topic-filter-card-top">
+              <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
+              <span class="album-count">{{ len $tagged }}</span>
+            </span>
+            <span class="topic-filter-card-intro">{{ .intro_zh }}</span>
+          </a>
+          {{ end }}
+          {{ end }}
+        </div>
       </div>
     </details>
   </div>


### PR DESCRIPTION
## What

The blog listing showed only **2 posts per row** because a 300px `Browse topics` right sidebar ate the width. This moves the topics into a compact **dropdown filter** above the grid, freeing the full content width so the cards go **3-up**.

## How

- `layouts/blog/list.html` + `layouts/zh/list.html`: replace the right `<aside>` sidebar with a `.blog-topbar` holding a native `<details>` dropdown — an `All posts` row plus one row per canonical topic (`data/blog_topics.yml`), each linking to its `/tags/` page as before. No JavaScript.
- `assets/scss/_custom_home.scss`: drop the `.blog-grid { 1fr 1fr }` sidebar override so the base `repeat(3, 1fr)` applies; add `.topic-filter*` styles; remove the now-unused `.blog-layout` / `.blog-sidebar` / `.album-*` rules.

## Responsive

3-up (desktop) → 2-up (≤992px) → 1-up (≤600px); the dropdown goes full-width on phones.

Builds clean with `hugo`; verified the rendered structure and links on both `/blog/` and `/zh/`.