### PR TITLE
Blog: re-title Meet Horizon UI series N/16 → N/17

### DIFF
--- a/content/blog/2026-06-21-horizon-ui-dashboards-and-mqe/index.md
+++ b/content/blog/2026-06-21-horizon-ui-dashboards-and-mqe/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 2/16: Dashboards That Adapt — MQE, Smart Widgets, and Numbers Humans Can Read"
+title: "Meet Horizon UI · 2/17: Dashboards That Adapt — MQE, Smart Widgets, and Numbers Humans Can Read"
 date: 2026-06-21
 author: Sheng Wu
 description: "Part 2 of the Horizon UI series: how its dashboards are built from MQE expressions, hide the widgets that don't apply to the entity in front of you (skipping their queries on the server), and render OK instead of 1 and 45.1k instead of 4.51e4."

--- a/content/blog/2026-06-21-horizon-ui-deployment-and-banyandb/index.md
+++ b/content/blog/2026-06-21-horizon-ui-deployment-and-banyandb/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 4/16: The Deployment Tab & BanyanDB Self-Observability"
+title: "Meet Horizon UI · 4/17: The Deployment Tab & BanyanDB Self-Observability"
 date: 2026-06-21
 author: Sheng Wu
 description: "Part 4 of the Meet Horizon UI series: the Deployment tab turns the topology map inward to show one clustered service's own instances, and BanyanDB is modeled as the role- and tier-aware cluster it is — SkyWalking finally watching its own database the way it watches everything else."

--- a/content/blog/2026-06-21-horizon-ui-topology-and-dependency/index.md
+++ b/content/blog/2026-06-21-horizon-ui-topology-and-dependency/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 3/16: Topology & Service Dependency"
+title: "Meet Horizon UI · 3/17: Topology & Service Dependency"
 date: 2026-06-21
 author: Sheng Wu
 description: "Part 3 of the Meet Horizon UI series: one template-driven topology engine that repaints for every layer, a filter to cut the noise, drill-down from a call into instances, the endpoint-dependency graph, and the cross-layer Smartscape overlay."

--- a/content/blog/2026-06-21-skywalking-horizon-ui-introduction/index.md
+++ b/content/blog/2026-06-21-skywalking-horizon-ui-introduction/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 1/16: SkyWalking's New Observability Console"
+title: "Meet Horizon UI · 1/17: SkyWalking's New Observability Console"
 date: 2026-06-21
 author: Sheng Wu
 description: "Introducing Apache SkyWalking Horizon UI — the next-generation web UI. A greenfield rewrite on the same OAP backend that you can observe, operate, govern, and customize, starting with a sidebar that mirrors your whole estate."

--- a/content/blog/2026-06-22-horizon-ui-3d-infrastructure-map/index.md
+++ b/content/blog/2026-06-22-horizon-ui-3d-infrastructure-map/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 5/16: The 3D Infrastructure Map"
+title: "Meet Horizon UI · 5/17: The 3D Infrastructure Map"
 date: 2026-06-22
 author: Sheng Wu
 description: "Part 5 of the Meet Horizon UI series: a single WebGL view of your whole deployment — every layer's services as cubes stacked on tiers, with live traffic, alarm beacons, and the calls between them."

--- a/content/blog/2026-06-22-horizon-ui-trace-explorer/index.md
+++ b/content/blog/2026-06-22-horizon-ui-trace-explorer/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 6/16: The Trace Explorer"
+title: "Meet Horizon UI · 6/17: The Trace Explorer"
 date: 2026-06-22
 author: Sheng Wu
 description: "Part 6 of the Meet Horizon UI series: a per-layer distributed-trace explorer — staged conditions, a duration-distribution chart you can box-select, three ways to read one trace, and a Zipkin tab beside the native one."

--- a/content/blog/2026-06-23-horizon-ui-browser-errors-and-source-maps/index.md
+++ b/content/blog/2026-06-23-horizon-ui-browser-errors-and-source-maps/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 8/16: Browser Errors & Source Maps"
+title: "Meet Horizon UI · 8/17: Browser Errors & Source Maps"
 date: 2026-06-23
 author: Sheng Wu
 description: "Part 8 of the Meet Horizon UI series: the browser agent's JavaScript-error feed, and the capability that makes it useful — resolving a minified production stack back to your original file, line, column, symbol and source, frame by frame."

--- a/content/blog/2026-06-23-horizon-ui-log-explorer/index.md
+++ b/content/blog/2026-06-23-horizon-ui-log-explorer/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Meet Horizon UI · 7/16: The Log Explorer"
+title: "Meet Horizon UI · 7/17: The Log Explorer"
 date: 2026-06-23
 author: Sheng Wu
 description: "Part 7 of the Meet Horizon UI series: two log surfaces — a stored, indexed, trace-correlated log stream with a level histogram, and an on-demand live tail of a Kubernetes pod's container logs."


### PR DESCRIPTION
The *Meet Horizon UI* series gains a dedicated post — **Inspect: Cross-Layer Query Power-Tools** (Metrics + Trace + Log inspect), split out of the Runtime Rules post — so the planned total is now **17**.

This re-titles the eight published posts' frontmatter from `N/16` to `N/17` so the series count stays consistent across the listing. Title-only change; no body or content edits.