### PR TITLE
Release Apache SkyWalking NodeJS 0.9.0

### DIFF
--- a/content/events/release-apache-skywalking-nodejs-0.9.0/index.md
+++ b/content/events/release-apache-skywalking-nodejs-0.9.0/index.md
@@ -1,0 +1,22 @@
+---
+title: "Release Apache SkyWalking for NodeJS 0.9.0"
+date: 2026-06-26
+author: SkyWalking Team
+description: "Release Apache SkyWalking NodeJS 0.9.0."
+---
+
+SkyWalking NodeJS 0.9.0 is released. Go to [downloads](/downloads) page to find release tars.
+
+## What's Changed
+* Modify mongoose call xxxx() throwing "is not a function" by @shivendoodeshmukh in https://github.com/apache/skywalking-nodejs/pull/128
+* fix: add destroy methods to prevent memory leaks in protocol clients by @wolfsilver in https://github.com/apache/skywalking-nodejs/pull/129
+* Bugfix: Pg plugin can't collect paramter values by @z2015 in https://github.com/apache/skywalking-nodejs/pull/131
+* fix: prevent OOM when collector unreachable; upgrade grpc-js to 1.14.4 by @wu-sheng in https://github.com/apache/skywalking-nodejs/pull/132
+* chore: add release automation scripts (release.sh + release-finalize.sh) by @wu-sheng in https://github.com/apache/skywalking-nodejs/pull/133
+
+## New Contributors
+* @shivendoodeshmukh made their first contribution in https://github.com/apache/skywalking-nodejs/pull/128
+* @wolfsilver made their first contribution in https://github.com/apache/skywalking-nodejs/pull/129
+* @z2015 made their first contribution in https://github.com/apache/skywalking-nodejs/pull/131
+
+**Full Changelog**: https://github.com/apache/skywalking-nodejs/compare/v0.8.0...v0.9.0

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -173,9 +173,9 @@
       user: apache
       repo: skywalking-nodejs
       docs:
-        - version: 0.8.0
-          link: https://github.com/apache/skywalking-nodejs/tree/v0.8.0
-          commitId: 4a610160c82a1ca4ab948dfecf3e1155f311ae70
+        - version: 0.9.0
+          link: https://github.com/apache/skywalking-nodejs/tree/v0.9.0
+          commitId: 1524588c5e2023e6dacf146cf39c671453bf78c2
     - name: Go Agent
       icon: skywalking-go
       description: The Go Agent for Apache SkyWalking, which provides the native tracing/metrics/logging abilities for Golang projects.

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -495,18 +495,18 @@
       icon: nodejs-agent
       description: The NodeJS Agent for Apache SkyWalking, which provides the native tracing abilities for NodeJS projects.
       source:
-        - version: v0.8.0
-          date: "2025-05-11"
+        - version: v0.9.0
+          date: "2026-06-26"
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/node-js/0.8.0/skywalking-nodejs-src-0.8.0.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/node-js/0.9.0/skywalking-nodejs-src-0.9.0.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/node-js/0.8.0/skywalking-nodejs-src-0.8.0.tgz.asc
+              link: https://downloads.apache.org/skywalking/node-js/0.9.0/skywalking-nodejs-src-0.9.0.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/node-js/0.8.0/skywalking-nodejs-src-0.8.0.tgz.sha512
+              link: https://downloads.apache.org/skywalking/node-js/0.9.0/skywalking-nodejs-src-0.9.0.tgz.sha512
       distribution:
-        - version: 0.8.0
-          date: "2025-05-11"
+        - version: 0.9.0
+          date: "2026-06-26"
           downloadLink:
             - name: Install via npm
               link: https://npmjs.com/package/skywalking-backend-js


### PR DESCRIPTION
Website update for the Apache SkyWalking NodeJS **0.9.0** release.

- Add the release event `content/events/release-apache-skywalking-nodejs-0.9.0/` (GitHub auto-notes).
- `data/releases.yml`: bump the NodeJS Agent source block to `v0.9.0` (+ npm distribution). The 0.9.0 src/asc/sha512 resolve on `downloads.apache.org` (verified 200); 0.8.0 is now archived.
- `data/docs.yml`: bump the NodeJS Agent docs pointer to `tree/v0.9.0`, commit `1524588c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)