### PR TITLE
docs(blog): fix Horizon UI container image coordinates in post 17 (Docker Hub)

### DIFF
--- a/content/blog/2026-06-30-horizon-ui-getting-started-and-migration/index.md
+++ b/content/blog/2026-06-30-horizon-ui-getting-started-and-migration/index.md
@@ -12,7 +12,7 @@ This is the seventeenth and final post in the [Meet Horizon UI](/blog/2026-06-21
 
 ## One image, one config
 
-Horizon ships as a **single container image** — the Vue UI and its Fastify BFF in one artifact — published to GHCR at `ghcr.io/apache/skywalking-horizon-ui`. There's one configuration file, `horizon.yaml`, and its defining trait is that **every field is an environment-variable token** (`${HORIZON_X:default}`) expanded *before* the YAML is parsed. So you can run the image with nothing mounted and set only the env vars you care about, or copy the file, edit it, and mount it.
+Horizon ships as a **single container image** — the Vue UI and its Fastify BFF in one artifact — published to Docker Hub as `apache/skywalking-ui`, with Horizon releases tagged `horizon-<version>` (and `latest`). There's one configuration file, `horizon.yaml`, and its defining trait is that **every field is an environment-variable token** (`${HORIZON_X:default}`) expanded *before* the YAML is parsed. So you can run the image with nothing mounted and set only the env vars you care about, or copy the file, edit it, and mount it.
 
 ```yaml
 # horizon.yaml — every field is an env token: ${HORIZON_X:default},
@@ -44,10 +44,10 @@ docker run -d --name horizon -p 8081:8081 \
   -e HORIZON_OAP_QUERY_URL=http://oap:12800 \
   -e HORIZON_OAP_ADMIN_URL=http://oap:17128 \
   -e HORIZON_AUTH_LOCAL_USERS='[{"username":"admin","passwordHash":"$argon2id$...","roles":["admin"]}]' \
-  ghcr.io/apache/skywalking-horizon-ui:<version>
+  apache/skywalking-ui:horizon-<version>
 ```
 
-Two things worth knowing on the first boot. There is **no default admin/admin** — with the `local` backend and no users (or `ldap` with no group mappings) the BFF starts but no one can sign in until you configure it; you generate password hashes with `pnpm --filter bff cli:hash`. And for reproducible deploys, **pin to a specific release tag or commit SHA** rather than a rolling tag.
+Two things worth knowing on the first boot. There is **no default admin/admin** — with the `local` backend and no users (or `ldap` with no group mappings) the BFF starts but no one can sign in until you configure it; you generate password hashes with `pnpm --filter bff cli:hash`. And for reproducible deploys, **pin to a specific `horizon-<version>` tag** rather than `latest`.
 
 ## What works on which OAP
 

--- a/content/zh/2026-06-30-horizon-ui-getting-started-and-migration/index.md
+++ b/content/zh/2026-06-30-horizon-ui-getting-started-and-migration/index.md
@@ -14,7 +14,7 @@ tags:
 
 ## 一个镜像，一份配置
 
-Horizon 以**单个容器镜像**发布：Vue UI 和 Fastify BFF 打在同一个 artifact 里，镜像位于 GHCR：`ghcr.io/apache/skywalking-horizon-ui`。配置文件只有一个：`horizon.yaml`。它最重要的特点是，**每个字段都是环境变量 token**（`${HORIZON_X:default}`），并且会在 YAML 解析之前展开。所以你可以不挂载任何文件，只用环境变量启动镜像；也可以复制这份文件，修改后挂载进去。
+Horizon 以**单个容器镜像**发布：Vue UI 和 Fastify BFF 打在同一个 artifact 里，镜像发布在 Docker Hub：`apache/skywalking-ui`，Horizon 的 release 用 `horizon-<version>` 标签（也提供 `latest`）。配置文件只有一个：`horizon.yaml`。它最重要的特点是，**每个字段都是环境变量 token**（`${HORIZON_X:default}`），并且会在 YAML 解析之前展开。所以你可以不挂载任何文件，只用环境变量启动镜像；也可以复制这份文件，修改后挂载进去。
 
 ```yaml
 # horizon.yaml — 每个字段都是 env token: ${HORIZON_X:default}
@@ -46,10 +46,10 @@ docker run -d --name horizon -p 8081:8081 \
   -e HORIZON_OAP_QUERY_URL=http://oap:12800 \
   -e HORIZON_OAP_ADMIN_URL=http://oap:17128 \
   -e HORIZON_AUTH_LOCAL_USERS='[{"username":"admin","passwordHash":"$argon2id$...","roles":["admin"]}]' \
-  ghcr.io/apache/skywalking-horizon-ui:<version>
+  apache/skywalking-ui:horizon-<version>
 ```
 
-第一次启动时有两点需要注意。第一，Horizon **没有默认的 admin/admin**。使用 `local` 后端但没有配置用户，或者使用 `ldap` 但没有配置 group mapping 时，BFF 会启动，但没人能登录；密码哈希可以用 `pnpm --filter bff cli:hash` 生成。第二，为了让部署可复现，生产环境应该固定到明确的 release tag 或 commit SHA，而不是使用滚动标签。
+第一次启动时有两点需要注意。第一，Horizon **没有默认的 admin/admin**。使用 `local` 后端但没有配置用户，或者使用 `ldap` 但没有配置 group mapping 时，BFF 会启动，但没人能登录；密码哈希可以用 `pnpm --filter bff cli:hash` 生成。第二，为了让部署可复现，生产环境应该固定到明确的 `horizon-<version>` 标签，而不是 `latest`。
 
 ## 哪些功能需要哪个 OAP
 


### PR DESCRIPTION
Post 17 (Getting Started & Migration) pointed at GHCR (`ghcr.io/apache/skywalking-horizon-ui`) for the container image. That registry holds the **per-commit CI/SHA builds**; the **user-facing release image** is mirrored to **Docker Hub** as `apache/skywalking-ui` (the repo shared with the previous UI), tagged `horizon-<version>` and `latest` — per the repo's `publish-image.yaml`.

Corrected in both EN and CN:
- prose: published to Docker Hub as `apache/skywalking-ui`, Horizon releases tagged `horizon-<version>` (and `latest`)
- the `docker run` example image → `apache/skywalking-ui:horizon-<version>`
- pin advice → pin to a specific `horizon-<version>` tag rather than `latest`

Content-only; Hugo builds clean (EN + zh).