### PR TITLE
SEO foundations, plus surface the AI story on the home page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,14 @@ When releasing a new version, update the component's `docs` section:
 2. **Add new versioned entry**: insert a `v<VERSION>` entry right after `Latest` with the same commitId and link pattern `/docs/<repo-slug>/v<VERSION>/readme/`.
 3. **Keep old versions** as-is.
 
+`Latest` and the newest `v<VERSION>` entry **must carry the same commitId**. Steps 1
+and 2 give that for free, but it is load-bearing beyond cosmetics: those two URL
+trees render the same source, and `layouts/partials/seo/doc-canonical-map.html`
+compares commitIds to decide which versioned pages point `rel=canonical` at
+`/latest/`. If `Latest` drifts, the duplicate pair silently competes in search and
+`/latest/` serves stale docs — BanyanDB sat on the v0.10.1 commit through two
+releases this way.
+
 ### Docs entry types
 Components use two styles in docs.yml:
 - **Hugo-hosted docs** (have `repoUrl`): use `/docs/<repo-slug>/<version>/readme/` links with `commitId`. These have `Next`, `Latest`, and versioned entries.
@@ -83,3 +91,26 @@ TAG_SHA=$(gh api repos/apache/<repo>/git/ref/tags/v<VERSION> --jq '.object.sha')
 # Dereference annotated tag to actual commit
 COMMIT_SHA=$(gh api repos/apache/<repo>/git/tags/$TAG_SHA --jq '.object.sha')
 ```
+
+## SEO metadata
+
+`layouts/partials/seo/` owns every search-facing tag; it is wired in once through
+`layouts/partials/hooks/head-end.html`, so the theme stays unforked.
+
+- `meta.html` — `rel=canonical`, `<meta name="description">`, en/zh `hreflang`
+- `doc-canonical-map.html` — the commitId rule described above
+- `schema.html` — JSON-LD (Organization, SoftwareApplication, BlogPosting, TechArticle, BreadcrumbList)
+- `lang.html` — the `<html lang>` value, derived from the URL because `content/zh`
+  is a section rather than a Hugo language
+
+Rules that are easy to break:
+
+- **`baseURL` in config.toml must stay absolute.** Sitemap `<loc>`, `og:url` and
+  canonical all derive from it, and the sitemaps.org spec rejects relative `<loc>`.
+- **`<title>` is emitted only by `themes/docsy/layouts/partials/head.html`.** Every
+  `baseof.html` used to repeat it, giving each page two. Do not add it back.
+- **`content/zh` holds Chinese blog posts only** — not a translated site. Adding a
+  `[languages]` block would restructure those URLs and strand the `layouts/zh/`
+  templates, for no gain.
+- The home page's `<title>` comes from `seo_title` in `content/_index.html` front
+  matter; every other page uses `Page | Apache SkyWalking`.

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -161,6 +161,11 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
       font-size: 46px; line-height: 1.1; font-weight: 800; color: $ink;
       letter-spacing: -1.1px; margin: 0 0 16px; border: 0; padding: 0;
       .accent {
+        // Keep "cloud-native and AI" whole: left to wrap freely it either
+        // strands "and AI" on its own line or breaks at the hyphen in
+        // "cloud-native". Forcing it to one unit moves the break to the
+        // phrase boundary after "for".
+        white-space: nowrap;
         background: linear-gradient(120deg, #3788D0, #E7136C 120%);
         -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
       }

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -194,7 +194,10 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
 
   // ---------- CAPABILITIES ----------
   .cap-grid {
-    display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px;
+    // Five pillars (GenAI joined in 10.4) plus a CTA tile fill a 3x2 grid
+    // exactly — no orphan card, and the sixth slot earns an internal link
+    // to /docs/ instead of sitting empty.
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
   }
   .cap-card {
     display: flex; flex-direction: column;   // so "Learn more" bottom-aligns across cards
@@ -209,12 +212,34 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     a  { font-size: 14px; font-weight: 600; color: $brand; text-decoration: none; margin-top: auto; &:hover { text-decoration: underline; } }
   }
   .cap-tag {
-    display: inline-block; padding: 4px 11px; border-radius: 999px;
+    // .cap-card is a column flexbox, which blockifies inline-block children and
+    // stretches them to the full card width — the pill has to opt out.
+    display: inline-block; align-self: flex-start;
+    padding: 4px 11px; border-radius: 999px;
     font-size: 12px; font-weight: 700; letter-spacing: .04em;
     &.tracing   { background: #fdecde; color: #c2580d; }
     &.metrics   { background: #e2f1fd; color: #1d6fb8; }
     &.logging   { background: #f0e7fd; color: #7c3aed; }
     &.profiling { background: #def5e7; color: #11814b; }
+    // Matches the AI topic colour in data/blog_topics.yml and the AI eco-card.
+    &.genai     { background: #fde8f3; color: #be2069; }
+  }
+  // Sixth tile: a link, not a pillar — dashed and tinted so it reads as an
+  // invitation rather than a fifth-and-a-half capability.
+  .cap-card--cta {
+    text-decoration: none;
+    border-style: dashed;
+    border-color: #c9d9ee;
+    background: linear-gradient(180deg, #f7faff 0%, #fff 75%);
+    &:hover { border-color: $brand; text-decoration: none; }
+    .cap-cta-eyebrow {
+      font-size: 12px; font-weight: 700; letter-spacing: .12em;
+      text-transform: uppercase; color: $muted;
+    }
+    h3 { margin-top: 16px; }
+    .cap-cta-more {
+      font-size: 14px; font-weight: 600; color: $brand; margin-top: auto;
+    }
   }
 
   // ---------- HERO MAIN SHOT (topology) ----------
@@ -861,6 +886,23 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     border-bottom: 1px solid $line;
     h1 { font-size: 40px; font-weight: 800; color: $ink; letter-spacing: -.8px; margin: 0 0 12px; border: 0; padding: 0; }
     p  { font-size: 16px; color: $body; line-height: 1.6; margin: 0; max-width: 660px; }
+  }
+
+  // Definitional block above the Chinese article list — the site's only
+  // Chinese-language explanation of what SkyWalking is.
+  .zh-intro {
+    padding: 26px 0 4px;
+    .container { max-width: 1200px; }
+    p { font-size: 15px; line-height: 1.85; color: $body; margin: 0 0 10px; max-width: 820px; }
+    .zh-intro-lede { font-size: 16.5px; color: $ink; strong { font-weight: 700; } }
+    .zh-intro-links {
+      display: flex; flex-wrap: wrap; gap: 18px; margin-top: 14px;
+      a {
+        font-size: 14px; font-weight: 600; color: $brand; text-decoration: none;
+        &:after { content: " →"; opacity: .75; }
+        &:hover { text-decoration: underline; }
+      }
+    }
   }
 
   .blog-wrap { max-width: 1200px; padding-top: 18px; padding-bottom: 64px; }
@@ -1531,4 +1573,18 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
 
 @media (max-width: 576px) {
   .map3d-play-label { font-size: 13px; }
+}
+
+// =====================================================================
+// Footer: community links without an iconfont glyph (B站, 掘金) render as
+// their name. Size them to sit on the same baseline as the icon links,
+// which carry Bootstrap's .h3.
+// =====================================================================
+.footer-link-text {
+  font-size: 15px;
+  font-weight: 600;
+  vertical-align: middle;
+  position: relative;
+  top: -6px;
+  a { text-decoration: none; &:hover { text-decoration: underline; } }
 }

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -169,7 +169,10 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
         -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
       }
     }
-    .lead { font-size: 16px; line-height: 1.6; color: $body; margin: 0; max-width: 520px; }
+    .lead {
+      font-size: 16px; line-height: 1.6; color: $body; margin: 0; max-width: 520px;
+      .lead-brand { font-weight: 700; color: $ink; }
+    }
   }
   .hero-cta {
     display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 30px;

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -161,10 +161,9 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
       font-size: 46px; line-height: 1.1; font-weight: 800; color: $ink;
       letter-spacing: -1.1px; margin: 0 0 16px; border: 0; padding: 0;
       .accent {
-        // Keep "cloud-native and AI" whole: left to wrap freely it either
-        // strands "and AI" on its own line or breaks at the hyphen in
-        // "cloud-native". Forcing it to one unit moves the break to the
-        // phrase boundary after "for".
+        // Keeps "cloud-native and AI" whole. Left to wrap it either strands
+        // "and AI" alone or, under text-wrap: balance, splits "cloud-native"
+        // at the hyphen.
         white-space: nowrap;
         background: linear-gradient(120deg, #3788D0, #E7136C 120%);
         -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
@@ -199,9 +198,7 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
 
   // ---------- CAPABILITIES ----------
   .cap-grid {
-    // Five pillars (GenAI joined in 10.4) plus a CTA tile fill a 3x2 grid
-    // exactly — no orphan card, and the sixth slot earns an internal link
-    // to /docs/ instead of sitting empty.
+    // Five pillars plus the CTA tile fill 3x2 exactly, leaving no orphan card.
     display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
   }
   .cap-card {
@@ -226,11 +223,9 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     &.metrics   { background: #e2f1fd; color: #1d6fb8; }
     &.logging   { background: #f0e7fd; color: #7c3aed; }
     &.profiling { background: #def5e7; color: #11814b; }
-    // Matches the AI topic colour in data/blog_topics.yml and the AI eco-card.
-    &.genai     { background: #fde8f3; color: #be2069; }
+    &.genai     { background: #fde8f3; color: #be2069; }  // data/blog_topics.yml
   }
-  // Sixth tile: a link, not a pillar — dashed and tinted so it reads as an
-  // invitation rather than a fifth-and-a-half capability.
+  // Dashed and tinted so it reads as a link, not a sixth capability.
   .cap-card--cta {
     text-decoration: none;
     border-style: dashed;
@@ -893,8 +888,6 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     p  { font-size: 16px; color: $body; line-height: 1.6; margin: 0; max-width: 660px; }
   }
 
-  // Definitional block above the Chinese article list — the site's only
-  // Chinese-language explanation of what SkyWalking is.
   .zh-intro {
     padding: 26px 0 4px;
     .container { max-width: 1200px; }
@@ -1580,11 +1573,8 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   .map3d-play-label { font-size: 13px; }
 }
 
-// =====================================================================
-// Footer: community links without an iconfont glyph (B站, 掘金) render as
-// their name. Size them to sit on the same baseline as the icon links,
-// which carry Bootstrap's .h3.
-// =====================================================================
+// Footer links with no iconfont glyph render as text; align them to the
+// baseline of the icon links, which carry Bootstrap's .h3.
 .footer-link-text {
   font-size: 15px;
   font-weight: 600;

--- a/config.toml
+++ b/config.toml
@@ -142,7 +142,9 @@ time_format_blog = "Jan 2, 2006"
 weight = 1
 
 [[menu.main]]
-    name = "Projects and Docs"
+    # Keep in step with content/docs/_index.md's title and the mobile sidebar —
+    # the same destination used to carry four different names.
+    name = "Documentation"
     weight = 10
     url = "/docs"
 
@@ -250,9 +252,13 @@ weight = 1
         desc = "Follow us on Twitter to get the latest news!"
 [[params.links.user]]
 	name ="Slack"
-	url = "http://s.apache.org/slack-invite"
+	# Same destination as the home page's Slack card. The old
+	# http://s.apache.org/slack-invite redirects to infra.apache.org/slack.html,
+	# which only offers self-signup to @apache.org addresses — a dead end for
+	# everyone else. Email is the only route that actually yields an invite.
+	url = "mailto:dev@skywalking.apache.org?subject=Request%20to%20join%20SkyWalking%20Slack"
 	icon = "iconfont icon-slack"
-        desc = "Join us!"
+        desc = "Ask the dev mailing list for a Slack invite"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.user]]
 	name ="Mailing list"
@@ -265,6 +271,16 @@ weight = 1
 	url = "https://github.com/apache/skywalking"
 	icon = "iconfont icon-github"
         desc = "Development takes place here!"
+# Chinese third-party platforms. No iconfont glyph exists for either, so the
+# footer renders these by name — see partials/footer.html.
+[[params.links.user]]
+	name = "B站"
+	url = "https://space.bilibili.com/390683219"
+        desc = "Talks and tutorials in Chinese on Bilibili"
+[[params.links.user]]
+	name = "掘金"
+	url = "https://juejin.cn/user/13673577331607"
+        desc = "Chinese articles on Juejin"
 
 [sitemap]
   changefreq = "daily"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,7 @@
-baseURL = "/"
+# Must be the absolute production URL: Hugo derives <loc> in sitemap.xml, og:url,
+# rel=canonical and the RSS links from it. A relative baseURL emits relative
+# <loc> values, which the sitemaps.org spec rejects outright.
+baseURL = "https://skywalking.apache.org/"
 title = "Apache SkyWalking"
 
 enableRobotsTXT = true

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
-# Must be the absolute production URL: Hugo derives <loc> in sitemap.xml, og:url,
-# rel=canonical and the RSS links from it. A relative baseURL emits relative
-# <loc> values, which the sitemaps.org spec rejects outright.
+# Must stay absolute: sitemap <loc>, og:url and rel=canonical derive from it,
+# and the sitemaps.org spec rejects relative <loc>.
 baseURL = "https://skywalking.apache.org/"
 title = "Apache SkyWalking"
 
@@ -142,8 +141,7 @@ time_format_blog = "Jan 2, 2006"
 weight = 1
 
 [[menu.main]]
-    # Keep in step with content/docs/_index.md's title and the mobile sidebar —
-    # the same destination used to carry four different names.
+    # Keep in step with content/docs/_index.md and the mobile sidebar.
     name = "Documentation"
     weight = 10
     url = "/docs"
@@ -252,10 +250,8 @@ weight = 1
         desc = "Follow us on Twitter to get the latest news!"
 [[params.links.user]]
 	name ="Slack"
-	# Same destination as the home page's Slack card. The old
-	# http://s.apache.org/slack-invite redirects to infra.apache.org/slack.html,
-	# which only offers self-signup to @apache.org addresses — a dead end for
-	# everyone else. Email is the only route that actually yields an invite.
+	# Not s.apache.org/slack-invite: it only self-signs-up @apache.org addresses.
+	# Must match the home page's Slack card.
 	url = "mailto:dev@skywalking.apache.org?subject=Request%20to%20join%20SkyWalking%20Slack"
 	icon = "iconfont icon-slack"
         desc = "Ask the dev mailing list for a Slack invite"
@@ -271,8 +267,7 @@ weight = 1
 	url = "https://github.com/apache/skywalking"
 	icon = "iconfont icon-github"
         desc = "Development takes place here!"
-# Chinese third-party platforms. No iconfont glyph exists for either, so the
-# footer renders these by name — see partials/footer.html.
+# No iconfont glyph for these two, so footer.html falls back to the name.
 [[params.links.user]]
 	name = "B站"
 	url = "https://space.bilibili.com/390683219"

--- a/content/_index.html
+++ b/content/_index.html
@@ -4,7 +4,7 @@ linkTitle = "Apache SkyWalking"
 # Without an explicit description Hugo's internal opengraph/twitter templates fall
 # back to .Summary, which on this page scrapes the hero SVG ("· APACHE SOFTWARE
 # FOUNDATION · OPEN SOURCE · ...") into every social card and search snippet.
-description = "Apache SkyWalking is an open source observability platform for cloud native architectures. It collects, analyzes, aggregates and visualizes distributed traces, metrics, logs, profiling and alarms from services, containers and Kubernetes infrastructure, with auto-instrumentation agents for Java, Go, Python, Node.js, PHP, Rust, Ruby and .NET, plus eBPF-based profiling."
+description = "Apache SkyWalking is an open source observability platform for cloud native architectures. It brings distributed tracing, metrics, logs, profiling and alarms into one platform, with auto-instrumentation agents for Java, Go, Python, Node.js, PHP, Rust, Ruby and .NET, plus eBPF on Kubernetes. It also monitors GenAI and LLM services — latency, token usage and estimated cost per provider and model — and ships a built-in assistant that investigates incidents in natural language."
 +++
 
 <!-- ===== HERO + PRODUCT BENTO (merged) ===== -->
@@ -30,11 +30,12 @@ description = "Apache SkyWalking is an open source observability platform for cl
 
     <div class="home-hero-grid">
       <div class="home-hero-text">
-        <h1>The observability platform for <span class="accent">cloud-native</span></h1>
+        <h1>The observability platform for <span class="accent">cloud-native and AI</span></h1>
         <p class="lead">
-          Apache SkyWalking collects, analyzes, aggregates and visualizes telemetry from
-          services and cloud-native infrastructure — distributed tracing, metrics, logs,
-          profiling and alarms in one platform, with many language agents and eBPF on Kubernetes.
+          Apache SkyWalking puts distributed tracing, metrics, logs, profiling and alarms
+          in one platform — across the services you run and the GenAI models they call,
+          down to tokens and cost. 10+ language agents, eBPF on Kubernetes, and a built-in
+          assistant you can ask in natural language.
         </p>
         <div class="hero-cta">
           <a href="/docs/#qs-showcase">
@@ -118,8 +119,8 @@ description = "Apache SkyWalking is an open source observability platform for cl
       </div>
       <div class="frow-copy">
         <span class="eyebrow">NEW · AI ASSISTANT</span>
-        <h2>Ask your observability in plain language</h2>
-        <p>Horizon's built-in assistant answers questions about your running system — <em>"what's unhealthy right now?"</em>, <em>"investigate latency for checkout"</em> — and replies with an ordered narrative built from the <strong>same charts, topology and tables</strong> as the rest of the UI, not a wall of text.</p>
+        <h2>Ask questions in natural language</h2>
+        <p>Horizon's built-in assistant answers questions about your running system — <em>"what's unhealthy right now?"</em>, <em>"investigate latency for checkout"</em> — with no MQE, PromQL or TraceQL to write. It replies with an ordered narrative built from the <strong>same charts, topology and tables</strong> as the rest of the UI, not a wall of text.</p>
         <ul class="frow-points">
           <li>
             <span class="fp-ic" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5v14a1 1 0 0 0 1 1h15"/><path d="M7.5 14l3.5-4 3 2.5 4.5-6"/></svg></span>
@@ -164,8 +165,8 @@ description = "Apache SkyWalking is an open source observability platform for cl
   <div class="container">
     <div class="section-head">
       <span class="eyebrow">WHAT YOU GET</span>
-      <h2>One platform for traces, metrics, logs and profiles</h2>
-      <p>A modern APM designed for cloud-native systems. Auto-instrument the languages you run, observe the kernel via eBPF, and store the volume natively in BanyanDB.</p>
+      <h2>One platform for traces, metrics, logs, profiles and GenAI</h2>
+      <p>An observability platform designed for cloud-native systems. Auto-instrument the languages you run, observe the kernel via eBPF, and store the volume natively in BanyanDB.</p>
     </div>
     <div class="cap-grid">
       <article class="cap-card">
@@ -192,6 +193,18 @@ description = "Apache SkyWalking is an open source observability platform for cl
         <p>CPU and async profiling bundled in language agents. eBPF profiler on Rover for Kubernetes deployments.</p>
         <a href="/docs/main/latest/en/concepts-and-designs/profiling/">Learn more →</a>
       </article>
+      <article class="cap-card">
+        <span class="cap-tag genai">GenAI</span>
+        <h3>LLM and GenAI monitoring</h3>
+        <p>Latency, traffic, success rate, input/output tokens and estimated cost, per provider and model — from SkyWalking, OTLP or Zipkin traces.</p>
+        <a href="/docs/main/latest/en/setup/service-agent/virtual-genai/">Learn more →</a>
+      </article>
+      <a class="cap-card cap-card--cta" href="/docs/">
+        <span class="cap-cta-eyebrow">And the rest</span>
+        <h3>See all capabilities</h3>
+        <p>Every server, agent, database and integration in the project — each with documentation for every released version.</p>
+        <span class="cap-cta-more">Browse documentation →</span>
+      </a>
     </div>
   </div>
 </section>
@@ -208,8 +221,8 @@ description = "Apache SkyWalking is an open source observability platform for cl
       <a class="eco-card" href="/docs/#Agents" style="--eco: #3788D0;">
         <span class="eco-ic"><svg viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h10" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg></span>
         <h4>Agents for your stack</h4>
-        <p>Java, Go, Python, Node.js, PHP, Rust, .NET, LUA, C++ and Client JavaScript — actively maintained.</p>
-        <span class="eco-more">14 language agents →</span>
+        <p>Java, Go, Python, Node.js, PHP, Rust, Ruby, .NET, LUA, C++ and Client JavaScript — actively maintained.</p>
+        <span class="eco-more">11 language agents →</span>
       </a>
       <a class="eco-card" href="/docs/skywalking-rover/latest/readme/" style="--eco: #11814b;">
         <span class="eco-ic"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3v4m0 10v4m9-9h-4M7 12H3m13.5-6.5l-2.8 2.8M9.3 14.7l-2.8 2.8m11 0l-2.8-2.8M9.3 9.3L6.5 6.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><circle cx="12" cy="12" r="2.4" stroke="currentColor" stroke-width="1.6"/></svg></span>
@@ -223,10 +236,10 @@ description = "Apache SkyWalking is an open source observability platform for cl
         <p>A native observability database built to ingest, analyze and store telemetry at scale.</p>
         <span class="eco-more">BanyanDB docs →</span>
       </a>
-      <a class="eco-card" href="/blog/" style="--eco: #be2069;">
+      <a class="eco-card" href="/tags/ai/" style="--eco: #be2069;">
         <span class="eco-ic"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3l2.2 5.3L20 9l-4 3.6L17 18l-5-2.7L7 18l1-5.4L4 9l5.8-.7L12 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg></span>
-        <h4>AI-assisted analysis</h4>
-        <p>ML baselines, HTTP URI pattern recognition and anomaly detection for smarter alerting.</p>
+        <h4>AI-assisted troubleshooting</h4>
+        <p>Ask Horizon UI to investigate in natural language — LLM-driven root cause, read-only and grounded in live data — plus ML baselines and anomaly detection.</p>
         <span class="eco-more">AI on the blog →</span>
       </a>
     </div>
@@ -280,11 +293,15 @@ description = "Apache SkyWalking is an open source observability platform for cl
         <p>Open a discussion or file an issue on GitHub — feature requests, questions and bug reports all welcome.</p>
         <span class="cc-more">GitHub Discussions →</span>
       </a>
-      <a class="community-card" href="http://s.apache.org/slack-invite" target="_blank" rel="noopener">
+      <!-- mailto, not http://s.apache.org/slack-invite: that redirects to
+           infra.apache.org/slack.html, which only offers self-signup to
+           @apache.org addresses. Kept in step with the Slack entry in
+           config.toml's [params.links.user], which the footer renders. -->
+      <a class="community-card" href="mailto:dev@skywalking.apache.org?subject=Request%20to%20join%20SkyWalking%20Slack">
         <span class="cc-ic"><i class="iconfont icon-slack"></i></span>
         <h4>Join our Slack</h4>
-        <p>Chat with maintainers and users in real time. Send a request to <span class="cc-mail">dev@skywalking.apache.org</span> and we'll invite you.</p>
-        <span class="cc-more">Get an invite →</span>
+        <p>Chat with maintainers and users in real time. ASF self-signup only works for <span class="cc-mail">@apache.org</span> addresses, so ask the dev mailing list and a maintainer will invite you.</p>
+        <span class="cc-more">dev@skywalking.apache.org →</span>
       </a>
       <a class="community-card" href="https://twitter.com/asfskywalking" target="_blank" rel="noopener">
         <span class="cc-ic"><i class="iconfont icon-twitter"></i></span>

--- a/content/_index.html
+++ b/content/_index.html
@@ -1,6 +1,10 @@
 +++
 title = "Apache SkyWalking"
 linkTitle = "Apache SkyWalking"
+# Without an explicit description Hugo's internal opengraph/twitter templates fall
+# back to .Summary, which on this page scrapes the hero SVG ("· APACHE SOFTWARE
+# FOUNDATION · OPEN SOURCE · ...") into every social card and search snippet.
+description = "Apache SkyWalking is an open source observability platform for cloud native architectures. It collects, analyzes, aggregates and visualizes distributed traces, metrics, logs, profiling and alarms from services, containers and Kubernetes infrastructure, with auto-instrumentation agents for Java, Go, Python, Node.js, PHP, Rust, Ruby and .NET, plus eBPF-based profiling."
 +++
 
 <!-- ===== HERO + PRODUCT BENTO (merged) ===== -->

--- a/content/_index.html
+++ b/content/_index.html
@@ -1,9 +1,10 @@
 +++
 title = "Apache SkyWalking"
 linkTitle = "Apache SkyWalking"
-# Without an explicit description Hugo's internal opengraph/twitter templates fall
-# back to .Summary, which on this page scrapes the hero SVG ("· APACHE SOFTWARE
-# FOUNDATION · OPEN SOURCE · ...") into every social card and search snippet.
+# Overrides the <title> tag on this page only.
+seo_title = "Apache SkyWalking — Observability for cloud-native and AI"
+# Required: without it Hugo's opengraph template falls back to .Summary, which
+# scrapes the hero SVG text into every social card.
 description = "Apache SkyWalking is an open source observability platform for cloud native architectures. It brings distributed tracing, metrics, logs, profiling and alarms into one platform, with auto-instrumentation agents for Java, Go, Python, Node.js, PHP, Rust, Ruby and .NET, plus eBPF on Kubernetes. It also monitors GenAI and LLM services — latency, token usage and estimated cost per provider and model — and ships a built-in assistant that investigates incidents in natural language."
 +++
 
@@ -293,10 +294,7 @@ description = "Apache SkyWalking is an open source observability platform for cl
         <p>Open a discussion or file an issue on GitHub — feature requests, questions and bug reports all welcome.</p>
         <span class="cc-more">GitHub Discussions →</span>
       </a>
-      <!-- mailto, not http://s.apache.org/slack-invite: that redirects to
-           infra.apache.org/slack.html, which only offers self-signup to
-           @apache.org addresses. Kept in step with the Slack entry in
-           config.toml's [params.links.user], which the footer renders. -->
+      <!-- Keep in step with the Slack entry in config.toml [params.links.user]. -->
       <a class="community-card" href="mailto:dev@skywalking.apache.org?subject=Request%20to%20join%20SkyWalking%20Slack">
         <span class="cc-ic"><i class="iconfont icon-slack"></i></span>
         <h4>Join our Slack</h4>

--- a/content/_index.html
+++ b/content/_index.html
@@ -31,9 +31,9 @@ description = "Apache SkyWalking is an open source observability platform for cl
 
     <div class="home-hero-grid">
       <div class="home-hero-text">
-        <h1>The observability platform for <span class="accent">cloud-native and AI</span></h1>
+        <h1>Observability for <span class="accent">cloud-native and AI</span></h1>
         <p class="lead">
-          Apache SkyWalking puts distributed tracing, metrics, logs, profiling and alarms
+          <strong class="lead-brand">Apache SkyWalking</strong> puts distributed tracing, metrics, logs, profiling and alarms
           in one platform — across the services you run and the GenAI models they call,
           down to tokens and cost. 10+ language agents, eBPF on Kubernetes, and a built-in
           assistant you can ask in natural language.

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -368,7 +368,7 @@
           link: /docs/skywalking-banyandb/next/readme/
         - version: Latest
           link: /docs/skywalking-banyandb/latest/readme/
-          commitId: dda5b5edfda8d90996f37fcb713d8b1035739dd4
+          commitId: 951e00e85b47b46cdabbe3d14e5be4a02b50dd29
         - version: v0.10.3
           link: /docs/skywalking-banyandb/v0.10.3/readme/
           commitId: 951e00e85b47b46cdabbe3d14e5be4a02b50dd29

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     {{ partial "blog-topic-styles.html" . }}
   </head>
   <body class="td-{{ .Kind }} td-blog">

--- a/layouts/contributors/baseof.html
+++ b/layouts/contributors/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/contributors/baseof.html
+++ b/layouts/contributors/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-contributors">
     <header>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -3,7 +3,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js td-docs">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-docs-landing">
     <header>{{ partial "navbar.html" . }}</header>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,6 +1,6 @@
 {{- /* /docs landing — light card grid, driven by data/docs.yml + data/stars.yml */ -}}
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js td-docs">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js td-docs">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/downloads/baseof.html
+++ b/layouts/downloads/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
 <head>
   {{ partial "head.html" . }}
-  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 </head>
 <body class="td-{{ .Kind }} td-downloads">
 <header>

--- a/layouts/downloads/baseof.html
+++ b/layouts/downloads/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
 <head>
   {{ partial "head.html" . }}
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/events/baseof.html
+++ b/layouts/events/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/events/baseof.html
+++ b/layouts/events/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-events">
     <header>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,2 +1,7 @@
-{{- /* Intentionally empty: the site uses the theme's system font stack
-       ($font-family-base) throughout — no third-party (Google) web fonts. */ -}}
+{{- /* No third-party (Google) web fonts: the site uses the theme's system font
+       stack ($font-family-base) throughout.
+
+       This hook runs at the end of themes/docsy/layouts/partials/head.html and is
+       where the site's SEO metadata is emitted, so the theme itself stays unforked. */ -}}
+{{ partial "seo/meta.html" . }}
+{{ partial "seo/schema.html" . }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -25,10 +25,6 @@
 			</li>
             {{ end }}
             {{ end }}
-            {{- /* Chinese blog: a direct link to /zh/, the only on-site destination
-                   this menu ever had. The B站 and 掘金 accounts that used to share
-                   the dropdown are third-party presence, not our content, and now
-                   sit in the footer next to Twitter and Slack. */ -}}
             {{ $zhActive := or (eq $sec "zh") (eq $sec "zh_tags") }}
             <li class="nav-item mr-3 mb-lg-0">
                 <a class="nav-link{{ if $zhActive }} active{{ end }}" href="/zh/"><span{{ if $zhActive }} class="active"{{ end }}>中文博客</span></a>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -25,15 +25,13 @@
 			</li>
             {{ end }}
             {{ end }}
+            {{- /* Chinese blog: a direct link to /zh/, the only on-site destination
+                   this menu ever had. The B站 and 掘金 accounts that used to share
+                   the dropdown are third-party presence, not our content, and now
+                   sit in the footer next to Twitter and Slack. */ -}}
+            {{ $zhActive := or (eq $sec "zh") (eq $sec "zh_tags") }}
             <li class="nav-item mr-3 mb-lg-0">
-                <span class="link dropdown blog">
-                    <a class="link-name nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">中文资料</a>
-                    <div class="dropdown-menu">
-                        <a class="dropdown-item" href="/zh/">博客</a>
-                        <a class="dropdown-item" href="https://space.bilibili.com/390683219" target="_blank" rel="noopener noreferrer">B站</a>
-                        <a class="dropdown-item" href="https://juejin.cn/user/13673577331607" target="_blank" rel="noopener noreferrer">掘金</a>
-                    </div>
-                </span>
+                <a class="nav-link{{ if $zhActive }} active{{ end }}" href="/zh/"><span{{ if $zhActive }} class="active"{{ end }}>中文博客</span></a>
             </li>
 
             {{ if  .Site.Params.versions }}

--- a/layouts/partials/seo/doc-canonical-map.html
+++ b/layouts/partials/seo/doc-canonical-map.html
@@ -1,0 +1,42 @@
+{{- /* Returns a slice of {from, to} URL-prefix pairs for versioned docs that are
+       an exact re-rendering of the `latest` alias.
+
+       docs.js builds one URL tree per entry in data/docs.yml, so `Latest` and the
+       newest tagged version are rendered twice from the *same* commitId — e.g.
+       /docs/main/latest/ and /docs/main/v10.4.0/ have identical article bodies and
+       differ only in nav hrefs and the version <select>. Both URLs stay live and
+       served; the tagged one just points rel=canonical at /latest/ so the pair
+       stops competing in search results.
+
+       This is keyed on commitId equality, so it corrects itself at every release:
+       once `Latest` advances to a new commit, the old tag no longer matches and
+       falls back to self-canonical. Genuinely older versions never appear here —
+       they self-canonicalise and remain independently indexable. */ -}}
+{{- $pairs := slice -}}
+{{- range $group := site.Data.docs -}}
+  {{- with $group.list -}}
+    {{- range $item := . -}}
+      {{- with $item.docs -}}
+        {{- $latestPrefix := "" -}}
+        {{- $latestCommit := "" -}}
+        {{- range $d := . -}}
+          {{- if and (eq $d.version "Latest") (default "" $d.commitId) (hasPrefix (default "" $d.link) "/docs/") -}}
+            {{- $latestCommit = $d.commitId -}}
+            {{- $latestPrefix = strings.TrimSuffix "readme/" $d.link -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if ne $latestPrefix "" -}}
+          {{- range $d := . -}}
+            {{- if and (ne $d.version "Latest") (eq (default "" $d.commitId) $latestCommit) (hasPrefix (default "" $d.link) "/docs/") -}}
+              {{- $from := strings.TrimSuffix "readme/" $d.link -}}
+              {{- if ne $from $latestPrefix -}}
+                {{- $pairs = $pairs | append (dict "from" $from "to" $latestPrefix) -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $pairs -}}

--- a/layouts/partials/seo/doc-canonical-map.html
+++ b/layouts/partials/seo/doc-canonical-map.html
@@ -1,17 +1,8 @@
-{{- /* Returns a slice of {from, to} URL-prefix pairs for versioned docs that are
-       an exact re-rendering of the `latest` alias.
-
-       docs.js builds one URL tree per entry in data/docs.yml, so `Latest` and the
-       newest tagged version are rendered twice from the *same* commitId — e.g.
-       /docs/main/latest/ and /docs/main/v10.4.0/ have identical article bodies and
-       differ only in nav hrefs and the version <select>. Both URLs stay live and
-       served; the tagged one just points rel=canonical at /latest/ so the pair
-       stops competing in search results.
-
-       This is keyed on commitId equality, so it corrects itself at every release:
-       once `Latest` advances to a new commit, the old tag no longer matches and
-       falls back to self-canonical. Genuinely older versions never appear here —
-       they self-canonicalise and remain independently indexable. */ -}}
+{{- /* {from, to} URL-prefix pairs for versioned doc trees that render the same
+       commitId as `Latest` — e.g. /docs/main/v10.4.0/ and /docs/main/latest/ are
+       the same document at two URLs, so the tagged one canonicalises to /latest/.
+       Keyed on commitId, so it self-corrects at each release; older versions never
+       match and stay self-canonical. Every URL remains served either way. */ -}}
 {{- $pairs := slice -}}
 {{- range $group := site.Data.docs -}}
   {{- with $group.list -}}

--- a/layouts/partials/seo/lang.html
+++ b/layouts/partials/seo/lang.html
@@ -1,11 +1,6 @@
-{{- /* Returns the BCP-47 language tag for the current page.
-
-       The site is configured as a single Hugo language (English), so every
-       baseof template that writes `lang="{{ .Site.Language.Lang }}"` emits
-       lang="en" — including the Chinese posts under content/zh and their
-       zh_tags taxonomy. Search engines (Baidu especially) use that attribute
-       to decide what language a document is in, so derive it from the URL
-       instead until/unless the site moves to a real [languages] config. */ -}}
+{{- /* BCP-47 tag for the page. content/zh holds Chinese posts but the site is a
+       single Hugo language, so .Site.Language.Lang reports "en" for them too;
+       derive it from the URL instead. */ -}}
 {{- $lang := site.Language.Lang -}}
 {{- if or (hasPrefix .RelPermalink "/zh/") (hasPrefix .RelPermalink "/zh_tags/") -}}
   {{- $lang = "zh-CN" -}}

--- a/layouts/partials/seo/lang.html
+++ b/layouts/partials/seo/lang.html
@@ -1,0 +1,13 @@
+{{- /* Returns the BCP-47 language tag for the current page.
+
+       The site is configured as a single Hugo language (English), so every
+       baseof template that writes `lang="{{ .Site.Language.Lang }}"` emits
+       lang="en" — including the Chinese posts under content/zh and their
+       zh_tags taxonomy. Search engines (Baidu especially) use that attribute
+       to decide what language a document is in, so derive it from the URL
+       instead until/unless the site moves to a real [languages] config. */ -}}
+{{- $lang := site.Language.Lang -}}
+{{- if or (hasPrefix .RelPermalink "/zh/") (hasPrefix .RelPermalink "/zh_tags/") -}}
+  {{- $lang = "zh-CN" -}}
+{{- end -}}
+{{- return $lang -}}

--- a/layouts/partials/seo/meta.html
+++ b/layouts/partials/seo/meta.html
@@ -1,0 +1,62 @@
+{{- $path := .RelPermalink -}}
+{{- $lang := partial "seo/lang.html" . -}}
+
+{{- /* --- rel=canonical -------------------------------------------------------
+       Self-canonical everywhere, except versioned doc trees that are a duplicate
+       rendering of /latest/ (see seo/doc-canonical-map.html), which point at the
+       /latest/ equivalent of the same page. */ -}}
+{{- $canonical := .Permalink -}}
+{{- range $p := partialCached "seo/doc-canonical-map.html" . -}}
+  {{- if hasPrefix $path $p.from -}}
+    {{- $canonical = absURL (printf "%s%s" $p.to (strings.TrimPrefix $p.from $path)) -}}
+  {{- end -}}
+{{- end -}}
+<link rel="canonical" href="{{ $canonical }}">
+
+{{- /* --- meta description ----------------------------------------------------
+       Hugo's internal opengraph template already emits og:description, but no
+       plain <meta name="description"> was ever rendered. Only emit one when the
+       page has a real description or usable prose — a duplicated boilerplate
+       description across 4k doc pages is worse than letting Google build its own
+       snippet from the content. */ -}}
+{{- $desc := default "" .Params.description -}}
+{{- if and (eq $desc "") (not .IsHome) .Content -}}
+  {{- $desc = .Summary | plainify | htmlUnescape | chomp -}}
+  {{- $desc = replaceRE `\s+` " " $desc | truncate 160 "…" -}}
+{{- end -}}
+{{- with $desc }}
+<meta name="description" content="{{ . }}">
+{{- end }}
+
+{{- /* --- hreflang ------------------------------------------------------------
+       content/zh holds Chinese translations of ~half the posts in content/blog,
+       matched by identical slug. Emit reciprocal alternates only when both pages
+       actually exist, so an unpaired post never claims a translation it lacks. */ -}}
+{{- $en := "" -}}
+{{- $zh := "" -}}
+{{- if hasPrefix $path "/blog/" -}}
+  {{- $slug := strings.TrimPrefix "/blog/" $path -}}
+  {{- if and (ne $slug "") (site.GetPage (printf "/zh/%s" $slug)) -}}
+    {{- $en = $path -}}
+    {{- $zh = printf "/zh/%s" $slug -}}
+  {{- end -}}
+{{- else if hasPrefix $path "/zh/" -}}
+  {{- $slug := strings.TrimPrefix "/zh/" $path -}}
+  {{- if and (ne $slug "") (site.GetPage (printf "/blog/%s" $slug)) -}}
+    {{- $zh = $path -}}
+    {{- $en = printf "/blog/%s" $slug -}}
+  {{- end -}}
+{{- end -}}
+{{- if and (ne $en "") (ne $zh "") }}
+<link rel="alternate" hreflang="en" href="{{ $en | absURL }}">
+<link rel="alternate" hreflang="zh-CN" href="{{ $zh | absURL }}">
+<link rel="alternate" hreflang="x-default" href="{{ $en | absURL }}">
+{{- end }}
+
+{{- /* Note: og:locale is emitted by Hugo's _internal/opengraph.html and is always
+       the site language ("en"), including on the Chinese pages. _internal
+       templates cannot be overridden, and a second og:locale here would just be a
+       conflicting duplicate — the first one wins in every parser. <html lang> and
+       the hreflang pair above are the signals search engines actually use, so this
+       is left alone; fixing it would mean replacing the internal OpenGraph call in
+       themes/docsy/layouts/partials/head.html with a local partial. */ -}}

--- a/layouts/partials/seo/meta.html
+++ b/layouts/partials/seo/meta.html
@@ -1,10 +1,7 @@
 {{- $path := .RelPermalink -}}
 {{- $lang := partial "seo/lang.html" . -}}
 
-{{- /* --- rel=canonical -------------------------------------------------------
-       Self-canonical everywhere, except versioned doc trees that are a duplicate
-       rendering of /latest/ (see seo/doc-canonical-map.html), which point at the
-       /latest/ equivalent of the same page. */ -}}
+{{- /* Self-canonical, except doc versions that duplicate /latest/. */ -}}
 {{- $canonical := .Permalink -}}
 {{- range $p := partialCached "seo/doc-canonical-map.html" . -}}
   {{- if hasPrefix $path $p.from -}}
@@ -13,12 +10,8 @@
 {{- end -}}
 <link rel="canonical" href="{{ $canonical }}">
 
-{{- /* --- meta description ----------------------------------------------------
-       Hugo's internal opengraph template already emits og:description, but no
-       plain <meta name="description"> was ever rendered. Only emit one when the
-       page has a real description or usable prose — a duplicated boilerplate
-       description across 4k doc pages is worse than letting Google build its own
-       snippet from the content. */ -}}
+{{- /* Omitted when there is nothing page-specific to say: one boilerplate
+       description repeated across 4k doc pages is worse than none. */ -}}
 {{- $desc := default "" .Params.description -}}
 {{- if and (eq $desc "") (not .IsHome) .Content -}}
   {{- $desc = .Summary | plainify | htmlUnescape | chomp -}}
@@ -28,10 +21,8 @@
 <meta name="description" content="{{ . }}">
 {{- end }}
 
-{{- /* --- hreflang ------------------------------------------------------------
-       content/zh holds Chinese translations of ~half the posts in content/blog,
-       matched by identical slug. Emit reciprocal alternates only when both pages
-       actually exist, so an unpaired post never claims a translation it lacks. */ -}}
+{{- /* Reciprocal alternates only where both slugs exist, so an unpaired post
+       never claims a translation it lacks. */ -}}
 {{- $en := "" -}}
 {{- $zh := "" -}}
 {{- if hasPrefix $path "/blog/" -}}
@@ -53,10 +44,7 @@
 <link rel="alternate" hreflang="x-default" href="{{ $en | absURL }}">
 {{- end }}
 
-{{- /* Note: og:locale is emitted by Hugo's _internal/opengraph.html and is always
-       the site language ("en"), including on the Chinese pages. _internal
-       templates cannot be overridden, and a second og:locale here would just be a
-       conflicting duplicate — the first one wins in every parser. <html lang> and
-       the hreflang pair above are the signals search engines actually use, so this
-       is left alone; fixing it would mean replacing the internal OpenGraph call in
-       themes/docsy/layouts/partials/head.html with a local partial. */ -}}
+{{- /* og:locale still reports "en" on Chinese pages: it comes from
+       _internal/opengraph.html, which cannot be overridden, and a second tag here
+       would only be a conflicting duplicate. Fixing it means replacing that
+       template call in head.html. */ -}}

--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -1,0 +1,114 @@
+{{- /* JSON-LD structured data.
+
+       Hugo's internal _internal/schema.html only emits a handful of bare itemprop
+       attributes, which neither Google's rich results nor LLM retrievers make much
+       use of. Emit real JSON-LD instead: Organization/SoftwareApplication on the
+       home page, BlogPosting on posts and release events, TechArticle plus a
+       BreadcrumbList on documentation pages. */ -}}
+
+{{- $lang := partial "seo/lang.html" . -}}
+{{- $org := dict
+      "@type" "Organization"
+      "@id" (absURL "#organization")
+      "name" "Apache SkyWalking"
+      "url" (absURL "")
+      "logo" (absURL "images/skywalking_400x400.png")
+      "sameAs" (slice
+        "https://github.com/apache/skywalking"
+        "https://twitter.com/asfskywalking"
+        "https://projects.apache.org/project.html?skywalking")
+      "parentOrganization" (dict
+        "@type" "Organization"
+        "name" "The Apache Software Foundation"
+        "url" "https://www.apache.org/")
+-}}
+{{- $publisher := dict "@id" (absURL "#organization") -}}
+
+{{- /* The Organization node is repeated in every page's @graph rather than only on
+       the home page: a bare "@id" reference to a node defined on a *different*
+       document is technically legal JSON-LD but consumers do not dereference it, so
+       publisher/author would resolve to nothing. */ -}}
+{{- $nodes := slice -}}
+
+{{- if .IsHome -}}
+  {{- /* Latest SkyWalking APM version, read defensively from data/releases.yml so a
+         reshuffle of that file can never fail the build. */ -}}
+  {{- $version := "" -}}
+  {{- with site.Data.releases -}}
+    {{- with index . 0 -}}
+      {{- with .list -}}
+        {{- with index . 0 -}}
+          {{- with .distribution -}}
+            {{- with index . 0 -}}
+              {{- $version = default "" .version -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $app := dict
+        "@type" "SoftwareApplication"
+        "name" "Apache SkyWalking"
+        "url" (absURL "")
+        "applicationCategory" "DeveloperApplication"
+        "applicationSubCategory" "Observability, Application Performance Monitoring, Distributed Tracing"
+        "operatingSystem" "Linux, macOS, Windows"
+        "description" site.Params.description
+        "downloadUrl" (absURL "downloads/")
+        "license" "https://www.apache.org/licenses/LICENSE-2.0"
+        "isAccessibleForFree" true
+        "author" $publisher
+        "offers" (dict "@type" "Offer" "price" "0" "priceCurrency" "USD")
+  -}}
+  {{- with $version -}}
+    {{- $app = merge $app (dict "softwareVersion" (strings.TrimPrefix "v" .)) -}}
+  {{- end -}}
+  {{- $nodes = $nodes | append $org -}}
+  {{- $nodes = $nodes | append (dict
+        "@type" "WebSite"
+        "@id" (absURL "#website")
+        "url" (absURL "")
+        "name" site.Title
+        "inLanguage" $lang
+        "publisher" $publisher) -}}
+  {{- $nodes = $nodes | append $app -}}
+{{- else if eq .Kind "page" -}}
+  {{- $isDoc := hasPrefix .RelPermalink "/docs/" -}}
+  {{- $type := cond $isDoc "TechArticle" "BlogPosting" -}}
+  {{- $article := dict
+        "@type" $type
+        "headline" .Title
+        "url" .Permalink
+        "mainEntityOfPage" (dict "@type" "WebPage" "@id" .Permalink)
+        "inLanguage" $lang
+        "publisher" $publisher
+  -}}
+  {{- with .Params.description -}}
+    {{- $article = merge $article (dict "description" .) -}}
+  {{- end -}}
+  {{- if not .Date.IsZero -}}
+    {{- $article = merge $article (dict "datePublished" (.Date.Format "2006-01-02")) -}}
+  {{- end -}}
+  {{- if not .Lastmod.IsZero -}}
+    {{- $article = merge $article (dict "dateModified" (.Lastmod.Format "2006-01-02")) -}}
+  {{- end -}}
+  {{- with .Params.author -}}
+    {{- $article = merge $article (dict "author" (dict "@type" "Person" "name" .)) -}}
+  {{- end -}}
+  {{- $nodes = $nodes | append $org -}}
+  {{- $nodes = $nodes | append $article -}}
+
+  {{- if $isDoc -}}
+    {{- $nodes = $nodes | append (dict
+          "@type" "BreadcrumbList"
+          "itemListElement" (slice
+            (dict "@type" "ListItem" "position" 1 "name" site.Title "item" (absURL ""))
+            (dict "@type" "ListItem" "position" 2 "name" "Projects and Docs" "item" (absURL "docs/"))
+            (dict "@type" "ListItem" "position" 3 "name" .Title "item" .Permalink))) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with $nodes }}
+<script type="application/ld+json">{{ (dict "@context" "https://schema.org" "@graph" .) | jsonify | safeJS }}</script>
+{{- end }}

--- a/layouts/partials/seo/schema.html
+++ b/layouts/partials/seo/schema.html
@@ -1,10 +1,6 @@
-{{- /* JSON-LD structured data.
-
-       Hugo's internal _internal/schema.html only emits a handful of bare itemprop
-       attributes, which neither Google's rich results nor LLM retrievers make much
-       use of. Emit real JSON-LD instead: Organization/SoftwareApplication on the
-       home page, BlogPosting on posts and release events, TechArticle plus a
-       BreadcrumbList on documentation pages. */ -}}
+{{- /* JSON-LD, which _internal/schema.html does not emit: Organization and
+       SoftwareApplication on the home page, BlogPosting on posts, TechArticle
+       plus BreadcrumbList on docs. */ -}}
 
 {{- $lang := partial "seo/lang.html" . -}}
 {{- $org := dict
@@ -24,15 +20,12 @@
 -}}
 {{- $publisher := dict "@id" (absURL "#organization") -}}
 
-{{- /* The Organization node is repeated in every page's @graph rather than only on
-       the home page: a bare "@id" reference to a node defined on a *different*
-       document is technically legal JSON-LD but consumers do not dereference it, so
-       publisher/author would resolve to nothing. */ -}}
+{{- /* Organization is repeated on every page: consumers do not dereference an
+       @id defined on another document, so publisher would resolve to nothing. */ -}}
 {{- $nodes := slice -}}
 
 {{- if .IsHome -}}
-  {{- /* Latest SkyWalking APM version, read defensively from data/releases.yml so a
-         reshuffle of that file can never fail the build. */ -}}
+  {{- /* Guarded so a reshuffle of data/releases.yml cannot fail the build. */ -}}
   {{- $version := "" -}}
   {{- with site.Data.releases -}}
     {{- with index . 0 -}}
@@ -104,7 +97,7 @@
           "@type" "BreadcrumbList"
           "itemListElement" (slice
             (dict "@type" "ListItem" "position" 1 "name" site.Title "item" (absURL ""))
-            (dict "@type" "ListItem" "position" 2 "name" "Projects and Docs" "item" (absURL "docs/"))
+            (dict "@type" "ListItem" "position" 2 "name" "Documentation" "item" (absURL "docs/"))
             (dict "@type" "ListItem" "position" 3 "name" .Title "item" .Permalink))) -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/projectdoc/baseof.html
+++ b/layouts/projectdoc/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/projectdoc/baseof.html
+++ b/layouts/projectdoc/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}  project-doc">
     <header>

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/layouts/tags/baseof.html
+++ b/layouts/tags/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}</title>
     {{ partial "blog-topic-styles.html" . }}
   </head>
   <body class="td-{{ .Kind }} td-blog">

--- a/layouts/tags/baseof.html
+++ b/layouts/tags/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}</title>

--- a/layouts/team/baseof.html
+++ b/layouts/team/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/team/baseof.html
+++ b/layouts/team/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-team">
     <header>

--- a/layouts/users/baseof.html
+++ b/layouts/users/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/users/baseof.html
+++ b/layouts/users/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-users">
     <header>

--- a/layouts/zh/baseof.html
+++ b/layouts/zh/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/layouts/zh/baseof.html
+++ b/layouts/zh/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     {{ partial "blog-topic-styles.html" . }}
   </head>
   <body class="td-{{ .Kind }} td-blog">

--- a/layouts/zh/list.html
+++ b/layouts/zh/list.html
@@ -17,6 +17,22 @@
   </div>
 </section>
 
+{{- /* Definitional block. The site had no Chinese page explaining what SkyWalking
+       actually is — every /zh/ article covers a specific topic — so Chinese search
+       and Chinese AI assistants had nothing authoritative on this domain to quote
+       for 「SkyWalking 是什么」. The article list below is unchanged. */ -}}
+<section class="zh-intro">
+  <div class="container">
+    <p class="zh-intro-lede"><strong>Apache SkyWalking 是一个开源的云原生可观测性平台</strong>，把分布式追踪、指标、日志、性能剖析和告警收在同一套数据模型里做关联分析，而不是各看各的。</p>
+    <p>接入以探针为主：Java、Go、Python、Node.js、PHP、Rust、Ruby、Nginx Lua 以及浏览器端 JS 都有对应实现，多数情况下不用改业务代码。装不了探针的服务，可以在 Kubernetes 上用基于 eBPF 的 Rover 补上进程与网络层的数据。采集到的数据由 OAP 后端做流式聚合与告警，默认写入社区自研、专为可观测性场景设计的 BanyanDB，也支持 Elasticsearch 等后端。</p>
+    <p class="zh-intro-links">
+      <a href="/docs/">文档</a>
+      <a href="/downloads/">下载</a>
+      <a href="https://github.com/apache/skywalking" target="_blank" rel="noopener">GitHub</a>
+    </p>
+  </div>
+</section>
+
 <div class="container blog-wrap">
   <div class="blog-topbar">
     <details class="topic-filter">

--- a/layouts/zh/list.html
+++ b/layouts/zh/list.html
@@ -17,10 +17,6 @@
   </div>
 </section>
 
-{{- /* Definitional block. The site had no Chinese page explaining what SkyWalking
-       actually is — every /zh/ article covers a specific topic — so Chinese search
-       and Chinese AI assistants had nothing authoritative on this domain to quote
-       for 「SkyWalking 是什么」. The article list below is unchanged. */ -}}
 <section class="zh-intro">
   <div class="container">
     <p class="zh-intro-lede"><strong>Apache SkyWalking 是一个开源的云原生可观测性平台</strong>，把分布式追踪、指标、日志、性能剖析和告警收在同一套数据模型里做关联分析，而不是各看各的。</p>

--- a/themes/docsy/layouts/_default/baseof.html
+++ b/themes/docsy/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js _default">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js _default">
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/themes/docsy/layouts/blog/baseof.html
+++ b/themes/docsy/layouts/blog/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/blog/baseof.html
+++ b/themes/docsy/layouts/blog/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-blog">
     <header>

--- a/themes/docsy/layouts/contributors/baseof.html
+++ b/themes/docsy/layouts/contributors/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/contributors/baseof.html
+++ b/themes/docsy/layouts/contributors/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}">
     <header>

--- a/themes/docsy/layouts/docs/baseof.html
+++ b/themes/docsy/layouts/docs/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js td-docs">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js td-docs">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/docs/baseof.html
+++ b/themes/docsy/layouts/docs/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js td-docs">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     <script async src="/js/github-buttons.js"></script>
   </head>
   <body class="td-{{ .Kind }}">

--- a/themes/docsy/layouts/downloads/baseof.html
+++ b/themes/docsy/layouts/downloads/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
 <head>
   {{ partial "head.html" . }}
-  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 </head>
 <body class="td-{{ .Kind }} td-docs td-downloads">
 <header>

--- a/themes/docsy/layouts/downloads/baseof.html
+++ b/themes/docsy/layouts/downloads/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
 <head>
   {{ partial "head.html" . }}
   <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/events/baseof.html
+++ b/themes/docsy/layouts/events/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/events/baseof.html
+++ b/themes/docsy/layouts/events/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}">
     <header>

--- a/themes/docsy/layouts/partials/footer.html
+++ b/themes/docsy/layouts/partials/footer.html
@@ -30,8 +30,6 @@
       {{- if $link.icon -}}
       <i class="{{ $link.icon }}"></i>
       {{- else -}}
-      {{- /* Links with no iconfont glyph (B站, 掘金) render as their name instead
-             of an empty <i>, so they are visible at all. */ -}}
       {{ $link.name }}
       {{- end -}}
     </a>

--- a/themes/docsy/layouts/partials/footer.html
+++ b/themes/docsy/layouts/partials/footer.html
@@ -24,9 +24,16 @@
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
-    <a class="text-color" target="_blank" href="{{ .url }}">
-      <i class="{{ .icon }}"></i>
+  {{- $link := . -}}
+  <li class="list-inline-item mx-2 {{ if $link.icon }}h3{{ else }}footer-link-text{{ end }}" data-toggle="tooltip" data-placement="top" title="{{ $link.name }}" aria-label="{{ $link.name }}">
+    <a class="text-color" target="_blank" rel="noopener" href="{{ $link.url }}">
+      {{- if $link.icon -}}
+      <i class="{{ $link.icon }}"></i>
+      {{- else -}}
+      {{- /* Links with no iconfont glyph (B站, 掘金) render as their name instead
+             of an empty <i>, so they are visible at all. */ -}}
+      {{ $link.name }}
+      {{- end -}}
     </a>
   </li>
   {{ end }}

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -12,7 +12,8 @@
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | relURL }}">
 {{ end -}}
 {{ partialCached "favicons.html" . }}
-<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+{{- /* The site's only <title>; do not re-add one to a baseof template. */ -}}
+<title>{{ if .IsHome }}{{ with .Params.seo_title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}

--- a/themes/docsy/layouts/partials/sidebar-skywalking.html
+++ b/themes/docsy/layouts/partials/sidebar-skywalking.html
@@ -8,8 +8,6 @@
         <div class="nav-item"><a href="/downloads/" class="nav-link{{ if eq $sec "downloads" }} router-link-active{{ end }}">Downloads</a></div>
         <div class="nav-item"><a href="/team/" class="nav-link{{ if eq $sec "team" }} router-link-active{{ end }}">Team</a></div>
         <div class="nav-item"><a href="/users/" class="nav-link{{ if eq $sec "users" }} router-link-active{{ end }}">Users</a></div>
-        {{- /* Mirrors the desktop navbar: a direct link to the on-site Chinese blog.
-               B站 and 掘金 are third-party accounts and live in the footer now. */ -}}
         <div class="nav-item"><a href="/zh/" class="nav-link{{ if or (eq $sec "zh") (eq $sec "zh_tags") }} router-link-active{{ end }}">中文博客</a></div>
         <div class="nav-item">
             <div class="dropdown-wrapper open">

--- a/themes/docsy/layouts/partials/sidebar-skywalking.html
+++ b/themes/docsy/layouts/partials/sidebar-skywalking.html
@@ -2,32 +2,15 @@
 <div class="sidebar">
     <nav class="nav-links">
         {{ $sec := .Section }}
-        <div class="nav-item"><a href="/docs/" class="nav-link{{ if eq $sec "docs" }} router-link-active{{ end }}">Projects and Documentation</a></div>
+        <div class="nav-item"><a href="/docs/" class="nav-link{{ if eq $sec "docs" }} router-link-active{{ end }}">Documentation</a></div>
         <div class="nav-item"><a href="/events/" class="nav-link{{ if eq $sec "events" }} router-link-active{{ end }}">Events</a></div>
         <div class="nav-item"><a href="/blog/" class="nav-link{{ if eq $sec "blog" }} router-link-active{{ end }}">Blog</a></div>
         <div class="nav-item"><a href="/downloads/" class="nav-link{{ if eq $sec "downloads" }} router-link-active{{ end }}">Downloads</a></div>
         <div class="nav-item"><a href="/team/" class="nav-link{{ if eq $sec "team" }} router-link-active{{ end }}">Team</a></div>
         <div class="nav-item"><a href="/users/" class="nav-link{{ if eq $sec "users" }} router-link-active{{ end }}">Users</a></div>
-        <div class="nav-item">
-            <div class="dropdown-wrapper open">
-                <a class="dropdown-title"><span>中文资料</span>
-                    <span class="arrow down"></span>
-                </a>
-                <ul class="nav-dropdown">
-                    <li class="dropdown-item">
-                        <a href="/zh/" class="nav-link external">博客</a>
-                    </li>
-                    <li class="dropdown-item">
-                        <a href="https://space.bilibili.com/390683219" target="_blank"
-                           rel="noopener noreferrer" class="nav-link external">B站</a>
-                    </li>
-                    <li class="dropdown-item">
-                        <a href="https://juejin.cn/user/13673577331607" target="_blank"
-                           rel="noopener noreferrer" class="nav-link external">掘金</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
+        {{- /* Mirrors the desktop navbar: a direct link to the on-site Chinese blog.
+               B站 and 掘金 are third-party accounts and live in the footer now. */ -}}
+        <div class="nav-item"><a href="/zh/" class="nav-link{{ if or (eq $sec "zh") (eq $sec "zh_tags") }} router-link-active{{ end }}">中文博客</a></div>
         <div class="nav-item">
             <div class="dropdown-wrapper open">
                 <a class="dropdown-title">

--- a/themes/docsy/layouts/projectDoc/baseof.html
+++ b/themes/docsy/layouts/projectDoc/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/projectDoc/baseof.html
+++ b/themes/docsy/layouts/projectDoc/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}  project-doc">
     <header>

--- a/themes/docsy/layouts/swagger/baseof.html
+++ b/themes/docsy/layouts/swagger/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/swagger/baseof.html
+++ b/themes/docsy/layouts/swagger/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link rel="stylesheet" type="text/css" href="/css/swagger-ui.css">
   </head>
   <body class="td-{{ .Kind }}">

--- a/themes/docsy/layouts/taxonomy/baseof.html
+++ b/themes/docsy/layouts/taxonomy/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/taxonomy/baseof.html
+++ b/themes/docsy/layouts/taxonomy/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} tags-list">
     <header>

--- a/themes/docsy/layouts/team/baseof.html
+++ b/themes/docsy/layouts/team/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/team/baseof.html
+++ b/themes/docsy/layouts/team/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}">
     <header>

--- a/themes/docsy/layouts/users/baseof.html
+++ b/themes/docsy/layouts/users/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/users/baseof.html
+++ b/themes/docsy/layouts/users/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}">
     <header>

--- a/themes/docsy/layouts/zh/baseof.html
+++ b/themes/docsy/layouts/zh/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/themes/docsy/layouts/zh/baseof.html
+++ b/themes/docsy/layouts/zh/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ partial "seo/lang.html" . }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-blog">
     <header>


### PR DESCRIPTION
## Why

The site emitted **no `rel=canonical` anywhere**, and `baseURL` was `"/"`. Hugo derives sitemap `<loc>`, `og:url` and canonical from `baseURL`, so the live sitemap contained relative locations:

```xml
<loc>/tags/ai/</loc>
<loc>/blog/2026-07-06-horizon-ui-ai-assistant/</loc>
```

The sitemaps.org spec requires an absolute URL there, which made all 4,704 entries unusable for discovery, and `robots.txt` (a bare `User-agent: *`) never advertised the sitemap anyway. Separately, GenAI/LLM monitoring shipped in 10.4 and the Horizon UI AI Assistant landed, but neither appeared on the home page.

## SEO

- **`baseURL`** → `https://skywalking.apache.org/`. `canonifyURLs` is off and templates use `relURL`, so internal links are unchanged; only sitemap/`og:url`/canonical/RSS gain absolute URLs.
- **`layouts/robots.txt`** — new, advertises the sitemap.
- **`layouts/partials/seo/`** — canonical, `<meta name="description">`, en↔zh `hreflang`, and JSON-LD (Organization, SoftwareApplication, BlogPosting, TechArticle, BreadcrumbList) replacing the internal template's bare itemprop microdata. Wired in through the existing `hooks/head-end.html`, so the theme stays unforked.
- **Versioned docs.** `docs.js` renders `Latest` and the newest tag from the same `commitId`, so e.g. `/docs/main/latest/` and `/docs/main/v10.4.0/` are the same document at two URLs with nothing saying which is authoritative. The tagged one now canonicalises to `/latest/`. Keyed on `commitId`, so it self-corrects at each release. **Every version URL stays live and served**; older versions self-canonicalise and remain independently indexable.
- **`<html lang>`.** `content/zh` holds Chinese blog posts but the site is a single Hugo language, so all 113 of them declared `lang="en"`. Derived from the URL instead.
- **Duplicate `<title>`.** Every page but the home page had two — `head.html` emitted one and all 21 `baseof.html` templates repeated it. `head.html` is now the sole owner.
- **`data/docs.yml`** — BanyanDB `Latest` pointed at `dda5b5ed`, which is the **v0.10.1** tag commit, so `/docs/skywalking-banyandb/latest/` served v0.10.1 docs through both the v0.10.2 and v0.10.3 releases. Realigned to v0.10.3.

## Home page

- Hero: **"Observability for cloud-native and AI"**, and a lead that says what the platform does now rather than "collects, analyzes, aggregates and visualizes".
- New **GenAI** capability card — latency, traffic, success rate, input/output tokens and estimated cost per provider and model, from SkyWalking, OTLP **or** Zipkin traces. The grid becomes 3×2: five pillars plus a "See all capabilities" tile, so no card is stranded.
- **"plain language" → "natural language"** throughout. Peer products (Dynatrace, Grafana, New Relic, OpenObserve, Arize) all use the latter; "plain language" names a different thing and is not what anyone searches for. Also fixes "Ask your observability", which had no object.
- Deliberately **not** branded "AI-native" — SkyWalking is a mature APM that gained AI capabilities, and none of the comparable products make that claim either.
- The agents card listed ten languages under a **"14 language agents"** link; now lists eleven (Ruby was missing) and says eleven, which is what `data/docs.yml` supports.
- The AI card linked to `/blog/` rather than `/tags/ai/`.

## Navigation

- The **中文资料** dropdown mixed one on-site destination with links to B站 and 掘金. Those platforms are ICP-filed and China-hosted, which this domain is not, so pointing at them from every page worked against the site's own Chinese content. **中文博客** is now a direct link to `/zh/`; the two accounts moved to the footer. Applied to the navbar and the mobile sidebar, which carried a second copy.
- The docs section was called **four different things** — "Projects and Docs" (navbar), "Projects and Documentation" (sidebar), "Documentation" (`<title>`), "Projects & documentation" (H1). Both nav labels are now "Documentation".
- `/zh/` gains a definitional block above the article list; the site had no Chinese page saying what SkyWalking is. The article list is unchanged.

## Fixes

- The Slack card and footer icon both pointed at `http://s.apache.org/slack-invite`, which redirects to `infra.apache.org/slack.html` and only offers self-signup to `@apache.org` addresses. Both now use the same `mailto:` to the dev list.
- `.cap-tag` declared `display:inline-block` inside a column flexbox, so every pill stretched to the full card width. Pre-existing.
- `footer.html` rendered an empty `<i>` for links with no iconfont glyph.

## Verification

Full local build, `hugo` exit 0:

| check | result |
|---|---|
| pages with `rel=canonical` | 4551 / 4552 |
| `<loc>` absolute / relative in sitemap | 4475 / **0** |
| zh pages reporting `zh-CN` | 113 / 113 |
| English pages wrongly marked zh | 0 |
| pages with reciprocal `hreflang` | 106 |
| pages with JSON-LD | 4426 |
| JSON-LD parse failures (250-page sample) | 0 |
| pages with more than one `<title>` | **0** |

The one page without a canonical is `public/3d-map-app/index.html`, the Vite SPA shell, which bypasses Hugo layouts.

Version-canonical spot check:

```
docs/skywalking-java/v9.6.0/  ->  canonical: .../skywalking-java/latest/   (same commitId)
docs/skywalking-java/v9.5.0/  ->  canonical: .../skywalking-java/v9.5.0/   (self)
```

200 sampled version-canonical targets all resolve to real built pages.

## Notes for reviewers

- **`og:locale` still reports `en` on Chinese pages.** It comes from Hugo's `_internal/opengraph.html`, which cannot be overridden; a second tag would only be a conflicting duplicate. Fixing it means replacing that template call with a local partial — deliberately out of scope here.
- Two home-page links resolve only after `docs.js` runs in CI: `virtual-genai/` (present in `skywalking` `v10.4.0`) and `horizon-ui/next/operate/ai-assistant/` (present on `skywalking-horizon-ui` `main`, and a pre-existing link). Worth a glance on the preview build.
- `CLAUDE.md` documents that `Latest` and the newest version entry must share a `commitId` — it is now load-bearing, not cosmetic.