### PR TITLE
Events: add a Community Calendar tab for conference talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,80 @@ If you want to display the summary in the popover in the lower right corner, you
 |img|The illustration|false|/images/skywalking_200x200.png|
 |poster|The poster|false|-|
 
+### Community Calendar
+
+Located at `data/talks.yml`, rendered at `/events/calendar/`. This is where conference
+talks, meetups and summits go — the release timeline at `/events/` is driven by
+`content/events` instead, and the two do not mix.
+
+To add or update a talk, edit `data/talks.yml` and open a pull request. You can do it
+entirely in the browser: use the **Add your talk** link on the calendar page, or the
+GitHub *Edit* button on the file. No local Hugo setup needed.
+
+```yaml
+events:
+  - event: Community Over Code Asia 2026
+    intro: >-
+      One or two sentences on what this conference is, for readers who
+      have never heard of it.
+    start: "2026-08-07"
+    end: "2026-08-09"          # omit for a single-day event
+    location: Beijing, China   # or "Online"
+    venue: Mountain Yang Hall  # optional
+    url: https://asia.communityovercode.org
+    recap: /zh/2023-08-20-coc-asia-2023/   # optional, a recap post on this site
+    talks:
+      - title: "Observing LLM Applications with SkyWalking 10.4"
+        speaker: 邵一鸣 YiMing Shao
+        date: "2026-08-09"     # only when it differs from the event start
+        time: 13:30 GMT+8
+        room: Mountain Yang Hall
+        url: https://asia.communityovercode.org/sessions/observability-1206017.html
+        video: https://www.bilibili.com/video/BVxxxxxxxxx
+        intro: >-
+          One or two sentences on what the session covers, in the same
+          language as the title.
+```
+
+Event fields:
+
+|Parameter|Description|Required|Default|
+|----|----|----|----|
+|event|Conference / meetup name|true|-|
+|start|Start date, `"YYYY-MM-DD"`, zero-padded|true|-|
+|end|End date, for multi-day events|false|`start`|
+|location|`City, Country`, or `Online`|true|-|
+|venue|Venue name|false|-|
+|intro|What this conference is, in one or two sentences|true|-|
+|url|Event home page. Omit rather than guess|false|-|
+|recap|Link to a recap post on this site|false|-|
+|talks|One or more sessions|true|-|
+
+Session fields, under `talks`:
+
+|Parameter|Description|Required|Default|
+|----|----|----|----|
+|title|Session title|true|-|
+|speaker|Speaker name. Use `中文名 English Name` when both are known|true|-|
+|intro|What the session covers. Condense the published abstract; don't invent one|false|-|
+|date|Session day, when it differs from the event `start`|false|`start`|
+|time|e.g. `13:30 GMT+8`|false|-|
+|room|Room name|false|-|
+|url|Session page|false|-|
+|video|Recording|false|-|
+|slides|Slide deck|false|-|
+
+Two things happen on their own, so you don't need to maintain them:
+
+- **Upcoming vs. past** is decided at build time from the event's `end` date, and the
+  site rebuilds daily, so an event moves itself into the past section once it is over.
+- **The year pager** under *Past* builds its year buttons and counts from the data, so
+  a new year appears as soon as an event needs it.
+
+If a required field is missing, or a date isn't in `YYYY-MM-DD` form, the build fails
+with a message naming the offending event — so a broken entry shows up as a failed
+check on the pull request rather than as a blank card on the site.
+
 ### Blog
 
 Located at `content/blog`. If you want to create a new blog, you need to create a new subdirectory under this directory. Here is a sample blog below.

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -669,6 +669,20 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     p  { font-size: 16px; color: $body; line-height: 1.6; margin: 0; max-width: 640px; a { color: $brand; } }
   }
 
+  // tab bar shared by /events/ and /events/calendar/
+  .ev-tabs {
+    display: inline-flex; gap: 4px; margin-top: 22px;
+    padding: 4px; border: 1px solid $line; border-radius: 999px; background: #fff;
+  }
+  .ev-tab {
+    display: inline-flex; align-items: center;
+    padding: 7px 18px; border-radius: 999px;
+    font-size: 14px; font-weight: 600; color: $body; text-decoration: none;
+    transition: background .16s ease, color .16s ease;
+    &:hover { background: #eef5fd; color: #2c6cb0; }
+    &.is-active { background: $brand; color: #fff; }
+  }
+
   .ev-wrap { max-width: 920px; padding-top: 36px; padding-bottom: 64px; }
 
   .ev-group { margin-bottom: 8px; }
@@ -759,6 +773,204 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     .ev-hero { padding-top: calc(4rem + 18px); h1 { font-size: 30px; } }
     .ev-item { padding-left: 44px; }
     .ev-author { margin-left: 0; width: 100%; }
+  }
+}
+
+// ---------- Events → Community calendar tab ----------
+.td-events {
+  .cal-wrap { max-width: 920px; padding-top: 30px; padding-bottom: 64px; }
+
+  .cal-stats {
+    display: flex; gap: 26px; flex-wrap: wrap;
+    padding-bottom: 22px; border-bottom: 1px solid $line;
+    font-size: 13px; color: $muted;
+    strong { font-size: 18px; font-weight: 800; color: $ink; margin-right: 5px; }
+  }
+
+  .cal-block { margin-top: 34px; }
+  .cal-head {
+    display: flex; align-items: center; gap: 10px;
+    font-size: 13px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase;
+    color: $muted; margin: 0 0 18px; border: 0; padding: 0;
+  }
+  .cal-pulse {
+    width: 8px; height: 8px; border-radius: 50%; background: #22a06b;
+    box-shadow: 0 0 0 0 rgba(34,160,107,.55);
+    animation: cal-pulse 2.2s infinite;
+  }
+  .cal-empty {
+    font-size: 14px; color: $body; background: #f7faff;
+    border: 1px dashed #d6e4f5; border-radius: 12px; padding: 18px 20px; margin: 0;
+  }
+
+  // "Past" heading + year pager on one row
+  .cal-past-head {
+    display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
+    margin-bottom: 4px;
+    .cal-head { margin-bottom: 0; }
+  }
+  .cal-years {
+    display: flex; gap: 6px; flex-wrap: wrap; margin-left: auto;
+  }
+  .cal-yr-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12.5px; font-weight: 700; color: $body;
+    background: #fff; border: 1px solid $line; border-radius: 999px;
+    padding: 5px 13px; cursor: pointer;
+    transition: background .16s ease, color .16s ease, border-color .16s ease;
+    &:hover { background: #eef5fd; border-color: #d6e4f5; color: #2c6cb0; }
+    &.is-active { background: $brand; border-color: $brand; color: #fff; }
+  }
+  .cal-yr-n {
+    font-size: 10.5px; font-weight: 700; line-height: 1;
+    padding: 2px 5px; border-radius: 999px;
+    background: #eef1f5; color: #5b6573;
+  }
+  .cal-yr-btn.is-active .cal-yr-n { background: rgba(255,255,255,.26); color: #fff; }
+  .cal-yeargroup[hidden] { display: none; }
+
+  .cal-year {
+    margin: 26px 0 14px;
+    span {
+      display: inline-block;
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 13px; font-weight: 700;
+      background: #eef5fd; border: 1px solid #d6e4f5; color: #2c6cb0;
+      border-radius: 999px; padding: 4px 14px;
+    }
+  }
+
+  .cal-card {
+    display: grid; grid-template-columns: 76px 1fr; gap: 20px;
+    background: #fff; border: 1px solid $line; border-radius: 12px;
+    padding: 18px 22px; margin-bottom: 14px;
+    transition: box-shadow .18s ease, border-color .18s ease;
+    &:hover { box-shadow: 0 16px 40px -22px rgba(17,24,39,.28); border-color: #d6e4f5; }
+    &.is-upcoming { border-color: #cfe6db; background: linear-gradient(180deg, #f6fcf9 0%, #fff 46%); }
+  }
+
+  // left-hand date chip
+  .cal-when {
+    display: flex; flex-direction: column; align-items: center; justify-content: flex-start;
+    padding-top: 2px; text-align: center;
+    .cal-mon {
+      font-size: 11px; font-weight: 800; letter-spacing: .1em;
+      text-transform: uppercase; color: #c01f68;
+    }
+    .cal-day {
+      font-size: 26px; font-weight: 800; color: $ink; line-height: 1.15;
+      letter-spacing: -.5px; white-space: nowrap;
+    }
+    .cal-yr {
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 11px; color: $muted;
+    }
+  }
+  .cal-card.is-upcoming .cal-when .cal-mon { color: #1b8158; }
+
+  .cal-meta {
+    display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+    font-size: 12px; color: $muted; margin-bottom: 6px;
+    time { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-weight: 600; }
+    .cal-loc::before { content: "· "; }
+  }
+  .cal-badge {
+    font-size: 10.5px; font-weight: 700; letter-spacing: .04em;
+    padding: 2px 9px; border-radius: 999px;
+    background: #e6f6ef; color: #1b8158; margin-left: auto;
+  }
+
+  .cal-title {
+    font-size: 18px; font-weight: 700; margin: 0 0 6px;
+    border: 0; padding: 0; line-height: 1.35; color: $ink;
+    a {
+      color: $brand; text-decoration: underline;
+      text-decoration-color: rgba(55,136,208,.35); text-underline-offset: 4px;
+      &:hover { color: #2c6cb0; text-decoration-color: currentColor; }
+    }
+  }
+
+  // the "↗" / "→" that marks a link as leaving the current page
+  .cal-ext {
+    display: inline-block; margin-left: 4px;
+    font-size: .82em; font-weight: 600; text-decoration: none;
+    vertical-align: baseline;
+  }
+
+  .cal-intro {
+    font-size: 13.5px; color: $body; line-height: 1.6; margin: 0 0 14px;
+    max-width: 62ch;
+  }
+
+  .cal-talks { list-style: none; margin: 0; padding: 0; }
+  .cal-talk {
+    position: relative; display: flex; gap: 10px;
+    padding: 8px 0; border-top: 1px solid #f0f2f5;
+    &:first-child { border-top: 0; padding-top: 0; }
+  }
+  .cal-talk-dot {
+    flex: 0 0 auto; width: 6px; height: 6px; margin-top: 8px;
+    border-radius: 50%; background: #c9d2dd;
+  }
+  .cal-card.is-upcoming .cal-talk-dot { background: #6cc09a; }
+  .cal-talk-body { min-width: 0; }
+  .cal-talk-title {
+    font-size: 14.5px; font-weight: 600; color: $ink; line-height: 1.45; margin: 0 0 2px;
+    a {
+      color: $ink; text-decoration: underline;
+      text-decoration-color: #cfe0f2; text-underline-offset: 3px;
+      &:hover { color: #2c6cb0; text-decoration-color: currentColor; }
+    }
+  }
+  .cal-talk-sub {
+    display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+    font-size: 12.5px; color: $muted; margin: 0;
+    .cal-speaker { font-weight: 600; color: $body; }
+    .cal-sep { color: #c9d2dd; }
+  }
+  .cal-talk-intro {
+    font-size: 13px; color: $body; line-height: 1.6; margin: 5px 0 0;
+    max-width: 68ch;
+  }
+  .cal-link {
+    font-size: 12px; font-weight: 600; color: $brand; text-decoration: none;
+    border: 1px solid #d6e4f5; border-radius: 999px; padding: 1px 9px; margin-left: 2px;
+    &:hover { background: #eef5fd; }
+  }
+  .cal-actions {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-top: 14px;
+  }
+  // the conference's own site — a button, so it reads as the way off this page
+  .cal-site {
+    display: inline-flex; align-items: center;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; font-weight: 600; color: $brand; text-decoration: none;
+    border: 1px solid #d6e4f5; border-radius: 999px; padding: 4px 12px;
+    background: #fff;
+    &:hover { background: #eef5fd; border-color: $brand; color: #2c6cb0; }
+  }
+  .cal-recap {
+    display: inline-block;
+    font-size: 13px; font-weight: 600; color: $brand; text-decoration: none;
+    &:hover { text-decoration: underline; }
+  }
+}
+
+@keyframes cal-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(34,160,107,.55); }
+  70%  { box-shadow: 0 0 0 7px rgba(34,160,107,0); }
+  100% { box-shadow: 0 0 0 0 rgba(34,160,107,0); }
+}
+
+@media (max-width: 576px) {
+  .td-events {
+    .ev-tabs { display: flex; width: 100%; }
+    .ev-tab { flex: 1; justify-content: center; padding: 7px 10px; font-size: 13px; }
+    .cal-card { grid-template-columns: 58px 1fr; gap: 14px; padding: 16px; }
+    .cal-when .cal-day { font-size: 21px; }
+    .cal-badge { margin-left: 0; }
+    .cal-stats { gap: 16px; }
   }
 }
 

--- a/content/events/calendar/_index.md
+++ b/content/events/calendar/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Community Calendar"
+linkTitle: "Calendar"
+description: "Upcoming and past conference talks, meetups and summits featuring Apache SkyWalking committers and community speakers."
+layout: calendar
+---

--- a/data/talks.yml
+++ b/data/talks.yml
@@ -1,0 +1,474 @@
+# Community calendar — conferences, meetups and summits where Apache SkyWalking
+# committers and community speakers appear.
+#
+# Rendered by layouts/events/calendar.html at /events/calendar/.
+# This file is NOT part of the release timeline at /events/ — that one is driven by
+# the markdown pages under content/events/.
+#
+# Ordering here is newest-first purely for the convenience of whoever edits it;
+# the layout sorts by `start` and splits upcoming vs. past on today's date.
+#
+# Event fields
+#   event     required  conference / meetup name
+#   start     required  "YYYY-MM-DD", zero-padded. Quoted by convention: Hugo's
+#                       current YAML parser keeps it a string either way, but the
+#                       quotes keep that independent of the parser, and the whole
+#                       layout sorts and groups on it as a string.
+#   end       optional  "YYYY-MM-DD" for multi-day events
+#   location  required  "City, Country", or "Online"
+#   venue     optional  venue name
+#   intro     required  one or two sentences on what the conference is, for readers
+#                       who have never heard of it. Keep it factual.
+#   url       optional  event home page. Omit rather than guess.
+#   recap     optional  link to a recap post on this site
+#   talks     required  one or more sessions, each with:
+#     title     required
+#     speaker   required  Preferred form is "中文名 English Name". The two
+#                         directions are NOT equally safe:
+#                           中文名 -> pinyin is deterministic, so adding the
+#                           romanisation of a Chinese name is fine.
+#                           English -> Chinese is NOT. Many characters share one
+#                           romanisation, so you would be inventing a person's
+#                           name. If the source gives only an English name, keep
+#                           only the English name — unless our own content already
+#                           records that person's Chinese name (a zh/en post pair,
+#                           data/committee.yml), which is a lookup, not a guess.
+#     intro     optional  one or two sentences on what the session covers, in the
+#                         same language as the title. Condense the published
+#                         abstract; do not invent one where none exists.
+#     date      optional  "YYYY-MM-DD" when the session day differs from `start`
+#     time      optional  e.g. "13:30 GMT+8"
+#     room      optional
+#     url       optional  session page
+#     video     optional  recording
+#     slides    optional  slide deck
+
+events:
+  - event: AWS Community Day 2026 Hong Kong
+    intro: >-
+      A community-organised, full-day AWS event run by the Hong Kong AWS user group — practitioner talks on cloud architecture, operations and observability rather than vendor sessions.
+    start: "2026-10-24"
+    location: Hong Kong
+    venue: VTC Auditorium
+    url: https://awscommunity.hk/
+    talks:
+      - title: "Beyond Flat Topologies: Visualizing the Cloud-Native Stack in 3D"
+        speaker: 吴晟 Sheng Wu
+
+  - event: Community Over Code Asia 2026
+    intro: >-
+      The Apache Software Foundation's official conference series in Asia, renamed from ApacheCon Asia. Three days of sessions spanning ASF projects and the community practices behind them.
+    start: "2026-08-07"
+    end: "2026-08-09"
+    location: Beijing, China
+    url: https://asia.communityovercode.org
+    talks:
+      - title: "Observing LLM Applications with SkyWalking 10.4: From Performance and Cost to Quality"
+        speaker: 邵一鸣 YiMing Shao
+        date: "2026-08-09"
+        time: 13:30 GMT+8
+        room: Mountain Yang Hall
+        url: https://asia.communityovercode.org/sessions/observability-1206017.html
+        intro: >-
+          How SkyWalking 10.4 instruments LLM interactions — chat, streaming, tool calling, RAG retrieval and vector search — then tracks token usage and inference cost alongside quality scored by configurable rubrics.
+      - title: "Engineering BanyanDB with AI Agents: Agentic Coding in Practice"
+        speaker: Youliang Huang
+        date: "2026-08-09"
+        time: 13:30 GMT+8
+        room: JingMing Hall
+        url: https://asia.communityovercode.org/sessions/agenticcoding-1185936.html
+        intro: >-
+          Agentic coding treated as an engineering workflow: engineers set the goals, constraints and architectural principles; agents handle exploration, execution, validation and iteration across design, implementation, debugging and testing.
+
+  - event: AWS Summit Hong Kong 2026
+    intro: >-
+      AWS's free one-day regional conference, with keynotes and technical breakouts for builders across Hong Kong. The 2026 edition centred on agentic AI as an enterprise workload.
+    start: "2026-06-17"
+    location: Hong Kong
+    venue: Hong Kong Convention and Exhibition Centre
+    url: https://aws.amazon.com/events/summits/hongkong/
+    talks:
+      - title: Agentic vibe coding in a mature OSS project
+        speaker: 吴晟 Sheng Wu
+        intro: >-
+          A lightning talk on constraining AI agents in a mature codebase — reviewing architectural changes, preserving compatibility contracts, and using human maintainership as the control loop. Covers what failed, where the agents needed correction, and what open source projects should weigh before letting agents touch critical code paths.
+
+  - event: CommunityOverCode Asia 2025
+    intro: >-
+      The ASF's Asia conference, held in Beijing. SkyWalking took three slots in the observability track — agent interoperability, a new language agent, and BanyanDB's storage tiering.
+    start: "2025-07-25"
+    end: "2025-07-27"
+    location: Beijing, China
+    url: https://asia.communityovercode.org/2025/
+    talks:
+      - title: "Bridging the Divide: Harmonizing Apache SkyWalking and OpenTelemetry in Production Environments"
+        speaker: Cheng Chen
+        date: "2025-07-27"
+        time: 14:30 GMT+8
+        room: Mtn Yang Hall
+        url: https://asia.communityovercode.org/2025/sessions/observability-914543.html
+        intro: >-
+          What breaks when SkyWalking and OpenTelemetry run side by side in production — class enhancement conflicts, startup failures, incompatible trace protocols — and how to keep multiple agents coexisting or migrate cleanly between stacks.
+      - title: Exploration and Practice of SkyWalking in Ruby Agent and MCP
+        speaker: Zixin Zhou
+        date: "2025-07-27"
+        time: 15:45 GMT+8
+        room: Mtn Yang Hall
+        url: https://asia.communityovercode.org/2025/sessions/observability-908230.html
+        intro: >-
+          Monitoring Ruby applications with SkyWalking: the design principles and implementation of the Ruby agent, plus integrating the Model Context Protocol with SkyWalking.
+      - title: "Optimizing Observability: Unveiling BanyanDB's Hot-Warm-Cold Architecture"
+        speaker: 高洪涛 Hongtao Gao
+        date: "2025-07-27"
+        time: 16:15 GMT+8
+        room: Mtn Yang Hall
+        url: https://asia.communityovercode.org/2025/sessions/observability-910659.html
+        intro: >-
+          Why a tiered hot-warm-cold design is the right answer for massive metrics, trace and log volumes, and how BanyanDB implements it while balancing query performance against storage cost.
+
+  - event: CommunityOverCode Asia 2024
+    intro: >-
+      The ASF's Asia conference, held in Hangzhou. SkyWalking ran a project stand alongside two cloud-native track sessions.
+    start: "2024-07-26"
+    end: "2024-07-28"
+    location: Hangzhou, China
+    url: https://asia.communityovercode.org/2024/
+    talks:
+      - title: Monitoring Kubernetes network traffic by using eBPF
+        speaker: 刘晗 Han Liu
+        date: "2024-07-28"
+        time: 16:45 GMT+8
+      - title: BanyanDB's New Column-Based Storage Engine
+        speaker: 高洪涛 Hongtao Gao
+        date: "2024-07-28"
+        time: 17:15 GMT+8
+
+  - event: SkyWalking Summit 2023
+    intro: >-
+      The SkyWalking community's own single-track summit, sponsored by ZMOps and Tetrate — a full day of roadmap, feature deep-dives, production war stories and open-source culture.
+    start: "2023-11-04"
+    location: Shanghai, China
+    venue: 上海大华虹桥假日酒店
+    url: /events/summit-23-cn/
+    recap: /zh/2023-11-04-skywalking-summit-shanghai/
+    talks:
+      - title: SkyWalking V9 In 2023 - 5 featured releases
+        speaker: 吴晟 Sheng Wu
+        video: https://www.bilibili.com/video/BV1Az4y1A7Pk
+      - title: 使用 Terraform 与 Ansible 快速部署 SkyWalking 集群
+        speaker: 柯振旭 Zhenxu Ke
+      - title: 基于 SkyWalking 构建全域一体化观测平台
+        speaker: 陈修能 Xiuneng Chen
+      - title: 云原生可观测性数据库 BanyanDB
+        speaker: 高洪涛 Hongtao Gao
+      - title: 基于 SkyWalking Agent 的性能剖析和实时诊断
+        speaker: 陆家靖 Jiajing Lu
+      - title: 太保科技 - 多云环境下 Zabbix 的运用实践
+        speaker: 田川 Chuan Tian
+      - title: KubeSphere 在可观测性领域的探索与实践
+        speaker: 霍秉杰 Bingjie Huo
+      - title: 大型跨国企业的微服务治理
+        speaker: 张文杰 Wenjie Zhang
+
+  - event: CommunityOverCode Asia 2023
+    intro: >-
+      The ASF's official Asia conference, the first edition held under the CommunityOverCode name after the rename from ApacheCon Asia.
+    start: "2023-08-18"
+    end: "2023-08-20"
+    location: Beijing, China
+    url: https://apachecon.com/acasia2023/
+    recap: /zh/2023-08-20-coc-asia-2023/
+    talks:
+      - title: SkyWalking 的 Golang 自动探针实践
+        speaker: 刘晗 Han Liu
+        video: https://www.bilibili.com/video/BV1U8411v71k
+        intro: >-
+          Go 探针长期以手动埋点为主，接入流程复杂、局限性强。这场分享讲如何用自动埋点简化接入，并突破框架对上下文传递的依赖限制。
+      - title: BanyanDB 一个高扩展性的分布式追踪数据库
+        speaker: 高洪涛 Hongtao Gao
+        video: https://www.bilibili.com/video/BV18K4y1w7eL
+        intro: >-
+          追踪数据量随微服务规模指数增长，传统关系型和时序数据库难以兼顾存储效率与查询灵活度。分享介绍 BanyanDB 的时间分片策略、多维索引设计，以及与其他数据库的对比。
+
+  - event: COSCUP 2023
+    intro: >-
+      Taiwan's largest community-run open-source conference — Conference for Open Source Coders, Users and Promoters — organised each year by local OSS communities.
+    start: "2023-07-29"
+    end: "2023-07-30"
+    location: Taipei, Taiwan
+    url: https://coscup.org/2023/
+    recap: /zh/2023-07-30-complete-auto-instrumentation-go-agent-for-distributed-tracing-and-monitoring/
+    talks:
+      - title: 在 Go 语言中使用自动增强探针完成链路追踪以及监控
+        speaker: 刘晗 Han Liu
+        date: "2023-07-30"
+        video: https://www.bilibili.com/video/BV1FV4y1B7p1
+        intro: >-
+          从为什么需要自动增强探针讲起，演示 Go Agent 的实际效果，拆解实现原理，并给出后续演进方向。
+
+  - event: 可观测性峰会 2023 Observability Summit
+    intro: >-
+      A one-day observability conference organised by China’s Cloud Native Community (云原生社区), mixing vendor-neutral panel discussions with practitioner talks.
+    start: "2023-04-22"
+    location: Beijing, China
+    venue: 北京奥加美术馆酒店
+    recap: /zh/2023-04-23-obs-summit-china/
+    talks:
+      - title: 圆桌讨论：云原生应用可观测性现状及趋势
+        speaker: 吴晟 Sheng Wu（嘉宾）
+        video: https://www.bilibili.com/video/BV1is4y1d7gd
+        intro: >-
+          罗广明主持，吴晟、向阳、乔新亮、董江同台，讨论云原生可观测性的落地现状与走向。
+      - title: 为 Apache SkyWalking 构建 Grafana dashboards — 基于对原生 PromQL 的支持
+        speaker: 万凯 Kai Wan
+        video: https://www.bilibili.com/video/BV1ms4y1d7NF
+        intro: >-
+          介绍 SkyWalking 的 PromQL Service：它是什么、能做什么，SkyWalking 中 metrics 的基本概念，以及如何用它搭建 Grafana dashboards。
+
+  - event: ApacheCon Asia 2022
+    intro: >-
+      The ASF's Asia conference, run online. SkyWalking filled most of the observability track — the platform overview, the native eBPF agent, AIOps alerting, BanyanDB and MAL-based infrastructure monitoring.
+    start: "2022-07-29"
+    end: "2022-07-31"
+    location: Online
+    url: https://apachecon.com/acasia2022/
+    talks:
+      - title: "Apache SkyWalking: An open source holistic application performance monitoring and observability tool"
+        speaker: Marc Navarro Sonnenfeld
+        date: "2022-07-29"
+        time: 14:00 GMT+8
+        url: https://apachecon.com/acasia2022/sessions/observability-1195.html
+        intro: >-
+          How SkyWalking treats metrics, logs and tracing as one correlated whole rather than three silos, at low latency and with 100% client-side sampling.
+      - title: Apache SkyWalking with Native eBPF Agent
+        speaker: 刘晗 Han Liu
+        date: "2022-07-29"
+        time: 14:40 GMT+8
+        url: https://apachecon.com/acasia2022/sessions/observability-1000.html
+        intro: >-
+          Using eBPF to pull data into SkyWalking that language agents cannot reach, and the native eBPF agent built for it.
+      - title: Approaching Robust Anomaly Alerting Capabilities at Apache SkyWalking with AIOps
+        speaker: Yihao Chen
+        date: "2022-07-29"
+        time: 15:20 GMT+8
+      - title: How SkyWalking Uses BanyanDB
+        speaker: 高洪涛 Hongtao Gao
+        date: "2022-07-29"
+        time: 16:40 GMT+8
+      - title: Apache SkyWalking MAL practice -- VMs and Kubernetes Monitoring
+        speaker: 万凯 Kai Wan
+        date: "2022-07-29"
+        time: 17:20 GMT+8
+
+  - event: ApacheCon@Home 2021
+    intro: >-
+      ApacheCon's second fully online edition. SkyWalking again anchored the Observability track, this time spanning browser monitoring, service mesh, BanyanDB and API gateways.
+    start: "2021-09-21"
+    end: "2021-09-23"
+    location: Online
+    url: https://apachecon.com/acah2021/
+    talks:
+      - title: End User Tracing in a SkyWalking-Observed Browser
+        speaker: 范秋霞 Qiuxia Fan
+        date: "2021-09-21"
+        time: 14:10 UTC
+        url: /blog/end-user-tracing-in-a-skywalking-observed-browser/
+        intro: >-
+          Extending SkyWalking's reach into the browser itself — performance metrics and error collection reported back to the backend, making the browser the starting point of a distributed trace.
+      - title: Un-breaking production bugs with non-breaking breakpoints
+        speaker: Brandon Fergerson
+        date: "2021-09-21"
+        time: 15:50 UTC
+        intro: >-
+          Debugging live applications with continuous-feedback tooling such as SourceMarker, using breakpoints that gather state without halting production traffic.
+      - title: The journey of migration between Apache SkyWalking and Service Mesh
+        speaker: Rei Shimizu
+        date: "2021-09-21"
+        time: 17:10 UTC
+        intro: >-
+          Building SkyWalking's C++ native SDK so it can act as a tracing provider inside the Istio service mesh.
+      - title: "BanyanDB: A Purpose-Built Observability database"
+        speaker: 高洪涛 Hongtao Gao
+        date: "2021-09-21"
+        time: 18:00 UTC
+        intro: >-
+          BanyanDB's design for ingesting metrics, tracing and logging data, and the limits of existing databases that made a purpose-built store worth writing.
+      - title: "Observability in Nginx: Apache APISIX it is"
+        speaker: 温铭 Ming Wen
+        date: "2021-09-21"
+        time: 18:50 UTC
+        intro: >-
+          Apache APISIX as an alternative to plain Nginx logging, bringing dynamic APIs and SkyWalking APM to existing Nginx users.
+
+  - event: SkyWalking Day 2021
+    intro: >-
+      The community's Beijing meet-up, co-hosted with Tencent and Tetrate. PMC members and committers presented on roadmap, storage internals, front-end monitoring and the Apache Way.
+    start: "2021-06-26"
+    location: Beijing, China
+    venue: 北京市海淀区西格玛大厦 B1 多功能厅
+    url: /events/skywalkingday-2021/
+    recap: /zh/skywalking-day-2021/
+    talks:
+      - title: Apache SkyWalking Landscape
+        speaker: 吴晟 Sheng Wu
+        video: https://www.bilibili.com/video/BV1HV411W7sr
+        intro: >-
+          SkyWalking 2020-2021 年的发展脉络与后续计划。
+      - title: 微服务可观测性分析平台的探索与实践
+        speaker: 凌若川 Ruochuan Ling
+        video: https://www.bilibili.com/video/BV15g411u7nh
+        intro: >-
+          腾讯云微服务团队构建云原生可观测性分析平台时遇到的性能与可用性挑战，架构设计上的取舍，以及下一阶段的演进方向。
+      - title: BanyanDB 数据模型背后的逻辑
+        speaker: 高洪涛 Hongtao Gao
+        video: https://www.bilibili.com/video/BV1Eo4y1C7KJ
+        intro: >-
+          从 RUM 猜想出发，讨论为什么 BanyanDB 选择的数据模型对 APM 数据更高效可靠，以及数据库设计中绕不开的取舍。
+      - title: Apache SkyWalking 如何做前端监控
+        speaker: 范秋霞 Qiuxia Fan
+        video: https://www.bilibili.com/video/BV1FL411W7XE
+        intro: >-
+          页面性能指标的收集与计算、前端错误日志采集与 Source Map 定位，以及浏览器端请求的追踪方法。
+      - title: 一名普通工程师，该如何正确的理解开源精神？
+        speaker: 王晔倞 Yeliang Wang
+        video: https://www.bilibili.com/video/BV1Bh411h7RE
+        intro: >-
+          为什么国内一些程序员会对开源产生误解，“开源≠自由≠非商业”的来龙去脉，以及普通工程师如何高效地向社区贡献。
+      - title: 可观测性技术生态和 OpenTelemetry 原理及实践
+        speaker: 陈一枭 Yixiao Chen
+        intro: >-
+          综述云原生可观测性技术生态，梳理 OpenTracing、OpenMetrics 到 OpenTelemetry 的标准演进，并介绍腾讯的落地实践。
+      - title: 利用 Apache SkyWalking 事件采集系统更快定位故障
+        speaker: 柯振旭 Zhenxu Ke
+        intro: >-
+          SkyWalking 的事件采集系统、上报事件的多种方式，以及如何结合 metrics 分析目标系统的性能问题。
+      - title: 可观测性自动注入技术原理探索与实践
+        speaker: 詹启新 Qixin Zhan
+        intro: >-
+          Java 字节码注入的技术原理，opentelemetry-java-instrumentation 的核心实现，以及自动注入在可观测领域的落地实践。
+      - title: 如何利用 Apache APISIX 提升 Nginx 的可观测性
+        speaker: 金卫 Wei Jin
+        intro: >-
+          Apache APISIX 在覆盖 Nginx 传统功能之外，如何与 SkyWalking 深度集成，无痛提升 Nginx 的可观测性。
+
+  - event: 开放原子开源基金会 2020 年度峰会 OpenAtom Foundation Annual Summit
+    intro: >-
+      The OpenAtom Foundation's annual summit, China's foundation-level open-source event. SkyWalking's slot covered how the project grows contributors rather than merely supporting users.
+    start: "2020-12-27"
+    location: Online
+    recap: /zh/2021-01-21-educate-community/
+    talks:
+      - title: Educate community Over Support community
+        speaker: 吴晟 Sheng Wu
+        video: https://www.bilibili.com/video/BV125411E7GK
+        intro: >-
+          SkyWalking 社区的成长方式：与其被动支持用户，不如主动教育社区、建设贡献者梯队。
+
+  - event: PyCon China 2020
+    intro: >-
+      The annual conference of the Chinese Python community, held online in 2020.
+    start: "2020-11-28"
+    location: Online
+    recap: /zh/2020-11-30-pycon/
+    talks:
+      - title: Python 微服务应用性能监控
+        speaker: 柯振旭 Zhenxu Ke
+        video: https://www.bilibili.com/video/BV1Ry4y167b6
+        intro: >-
+          SkyWalking 在微服务架构中要解决的问题，如何近乎自动化地监控 Python 后端服务，以及 Python 探针的实现技术解读。
+
+  - event: SkyWalking DevCon 2020
+    intro: >-
+      SkyWalking's own developer day in Beijing — community founder, PMC members and committers on site, joined by Apache Local Community Beijing on the Apache Way.
+    start: "2020-11-14"
+    location: Beijing, China
+    recap: /zh/2020-11-23-devcon/
+    talks:
+      - title: SkyWalking's 2019-2020 and beyond
+        speaker: 吴晟 Sheng Wu
+        video: https://www.bilibili.com/video/BV1ay4y16755
+      - title: 贝壳全链路跟踪实践
+        speaker: 赵禹光 Yuguang Zhao
+      - title: SkyWalking 在百度爱番番部门实践
+        speaker: 刘嘉鹏 Jiapeng Liu
+      - title: 非计算机背景的同学如何贡献开源
+        speaker: 适兕 Shisi
+        video: https://www.bilibili.com/video/BV12v411t7yt
+        intro: >-
+          从软件供应的生产、分发、消费三个角度，探讨一个开源项目究竟需要怎样的专业背景多样性，并以 ALC Beijing 为例说明。
+      - title: 如何从 Apache SkyWalking 社区学习 Apache Way
+        speaker: 温铭 Ming Wen
+      - title: Apache SkyWalking 在小米公司的应用
+        speaker: 宋振东 Zhendong Song
+      - title: Istio 全生命周期监控
+        speaker: 高洪涛 Hongtao Gao
+      - title: 针对 HikariCP 数据库连接池的监控
+        speaker: 张鑫 Xin Zhang
+      - title: SkyWalking 与 Nginx 的优化实践
+        speaker: 王院生 Yuansheng Wang
+        video: https://www.bilibili.com/video/BV1xZ4y1G7D7
+
+  - event: COSCon'20 中国开源年会
+    intro: >-
+      China Open Source Conference, the annual community event organised by KAIYUANSHE (开源社). SkyWalking appeared in the cloud-native and microservices track.
+    start: "2020-10-25"
+    location: Online
+    recap: /zh/2020-10-25-coscon20-swck/
+    talks:
+      - title: Apache SkyWalking Cloud on Kubernetes
+        speaker: 高洪涛 Hongtao Gao
+        video: https://www.bilibili.com/video/BV1ia411c7Hc
+        intro: >-
+          SkyWalking 社区用 Operator 模式构建 Kubernetes PaaS 组件的尝试：项目动机与设计理念、核心组件的发布更新与维护、与 Istio 的自动集成，以及后续规划。
+
+  - event: ApacheCon@Home 2020
+    intro: >-
+      ApacheCon's fully online 2020 edition. SkyWalking anchored the Observability track, alongside a keynote on the ASF's growth in China.
+    start: "2020-09-29"
+    end: "2020-10-01"
+    location: Online
+    url: https://www.apachecon.com/acah2020/
+    talks:
+      - title: "Keynote: Apache grows in China"
+        speaker: 吴晟 Sheng Wu
+        url: /blog/2020-11-21-apachecon-keynote/
+        video: https://www.youtube.com/watch?v=26aFGdbZvac
+        intro: >-
+          China topped the ASF download statistics in the FY2020 report. Three years of Chinese developers, companies and new projects joining the foundation — what changed, and what it asks of the wider community.
+      - title: The history of distributed tracing storage
+        speaker: 高洪涛 Hongtao Gao
+        url: /blog/2020-11-21-apachecon-obs-storage/
+        video: https://www.youtube.com/watch?v=iQ0tODBoh1k
+        intro: >-
+          How SkyWalking's storage module evolved, and with it the tracing storage layer in general — from traditional relational databases to document-based search engines, and what that leaves open to organisations today.
+      - title: SourceMarker - Continuous Feedback for Developers
+        speaker: Brandon Fergerson
+        url: /blog/2020-11-21-apachecon-obs-sourcemarker/
+        video: https://www.youtube.com/watch?v=IWounkxhfi0
+        intro: >-
+          Monitoring is built for operators who think in systems, not in source code — yet building and operating keep blurring together. Combining IDE and APM technology gives developers continuous feedback from inception to production.
+      - title: Improve Apache APISIX observability with Apache SkyWalking
+        speaker: 王院生 Yuansheng Wang
+        url: /blog/2020-11-21-apachecon-obs-apisix/
+        video: https://www.youtube.com/watch?v=DleVJwPs4i4
+        intro: >-
+          APISIX's plugin mechanism wires in SkyWalking quickly, making the full life cycle of a request visible from the edge through to internal services.
+      - title: Another backend storage solution for the APM system
+        speaker: Juan Pan
+        url: /blog/2020-11-21-apachecon-obs-shardingsphere/
+        video: https://www.youtube.com/watch?v=OazS_3r3NM4
+        intro: >-
+          APM backends need massive storage that stays simple, has few dependencies and a widely understood query language. This talk argues the NewSQL angle, using Apache ShardingSphere to extend SkyWalking's storage capability.
+
+  - event: 云原生学院 Cloud Native Academy
+    intro: >-
+      An online live-stream series run by China’s Cloud Native Community (云原生社区), pairing a single deep-dive topic with audience Q&A.
+    start: "2020-08-13"
+    location: Online
+    recap: /zh/2020-08-13-cloud-native-academy/
+    talks:
+      - title: 后分布式追踪时代的性能问题定位——方法级性能剖析
+        speaker: 吴晟 Sheng Wu
+        video: https://www.bilibili.com/video/BV1D541187kC
+        intro: >-
+          分布式追踪兴起的背景、SkyWalking 与其他追踪系统的异同、定位问题的流程与方法，以及性能剖析的由来和优势。

--- a/layouts/events/calendar.html
+++ b/layouts/events/calendar.html
@@ -1,0 +1,268 @@
+{{ define "main" }}
+{{/*
+  Community calendar. Data lives in data/talks.yml; nothing here reads
+  content/events/, so the release timeline in events/list.html is untouched.
+*/}}
+{{/*
+  Schema check. A contributor adding a talk edits data/talks.yml straight in the
+  GitHub web editor, so the build is the only thing standing between a typo and
+  production. Malformed YAML already fails in Hugo's data loader; these checks
+  cover the case it cannot see — well-formed YAML that omits a required field,
+  which would otherwise render a silently blank card. errorf fails the build, so
+  it surfaces as a red check on the PR rather than shipping.
+*/}}
+{{ range $i, $ev := .Site.Data.talks.events }}
+  {{ $at := printf "data/talks.yml: event #%d (%s)" (add $i 1) (default "unnamed" $ev.event) }}
+  {{ range slice "event" "start" "location" "intro" }}
+    {{ if not (index $ev .) }}{{ errorf "%s is missing required field %q" $at . }}{{ end }}
+  {{ end }}
+  {{ range $f := slice "start" "end" }}
+    {{ with index $ev $f }}
+      {{ if not (findRE `^\d{4}-\d{2}-\d{2}$` .) }}
+        {{ errorf "%s has %s: %q — expected \"YYYY-MM-DD\", zero-padded (e.g. \"2026-08-07\", not \"2026-8-7\")" $at $f . }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ if not $ev.talks }}{{ errorf "%s lists no talks" $at }}{{ end }}
+  {{ range $j, $t := $ev.talks }}
+    {{ range slice "title" "speaker" }}
+      {{ if not (index $t .) }}
+        {{ errorf "%s, talk #%d is missing required field %q" $at (add $j 1) . }}
+      {{ end }}
+    {{ end }}
+    {{ with $t.date }}
+      {{ if not (findRE `^\d{4}-\d{2}-\d{2}$` .) }}
+        {{ errorf "%s, talk %q has date: %q — expected a quoted \"YYYY-MM-DD\"" $at $t.title . }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $now := now }}
+{{ $upcoming := slice }}
+{{ $past := slice }}
+{{ range .Site.Data.talks.events }}
+  {{ $last := time.AsTime (default .start .end) }}
+  {{/* an event stays "upcoming" until the day after it ends */}}
+  {{ if ge ($last.AddDate 0 0 1).Unix $now.Unix }}
+    {{ $upcoming = $upcoming | append . }}
+  {{ else }}
+    {{ $past = $past | append . }}
+  {{ end }}
+{{ end }}
+{{ $upcoming = sort $upcoming "start" "asc" }}
+{{ $past = sort $past "start" "desc" }}
+{{ $talkCount := 0 }}
+{{ range .Site.Data.talks.events }}{{ $talkCount = add $talkCount (len .talks) }}{{ end }}
+
+<section class="ev-hero">
+  <div class="container">
+    <span class="eyebrow">EVENTS &amp; RELEASES</span>
+    <h1>Where to meet the SkyWalking community</h1>
+    <p>Conference talks, meetups and summits featuring SkyWalking committers and community
+      speakers. Speaking about SkyWalking somewhere?
+      <a href="https://github.com/apache/skywalking-website/edit/master/data/talks.yml">Add your talk</a>.</p>
+    {{ partial "events-tabs.html" (dict "active" "calendar") }}
+  </div>
+</section>
+
+<div class="container cal-wrap">
+  <div class="cal-stats">
+    <span><strong>{{ len $upcoming }}</strong> upcoming</span>
+    <span><strong>{{ len .Site.Data.talks.events }}</strong> events</span>
+    <span><strong>{{ $talkCount }}</strong> talks</span>
+  </div>
+
+  <section class="cal-block">
+    <h2 class="cal-head"><span class="cal-pulse" aria-hidden="true"></span>Upcoming</h2>
+    {{ if $upcoming }}
+      {{ range $upcoming }}
+        {{ template "cal-card" (dict "ev" . "now" $now "upcoming" true) }}
+      {{ end }}
+    {{ else }}
+      <p class="cal-empty">No events scheduled right now — watch the
+        <a href="https://lists.apache.org/list.html?dev@skywalking.apache.org">dev mailing list</a>
+        for the next announcement.</p>
+    {{ end }}
+  </section>
+
+  {{ if $past }}
+  {{/* distinct years, newest first — $past is already sorted desc */}}
+  {{ $years := slice }}
+  {{ range $past }}
+    {{ $y := substr .start 0 4 }}
+    {{ if not (in $years $y) }}{{ $years = $years | append $y }}{{ end }}
+  {{ end }}
+  <section class="cal-block">
+    <div class="cal-past-head">
+      <h2 class="cal-head">Past</h2>
+      <div class="cal-years" role="tablist" aria-label="Show past events by year">
+        {{ range $years }}
+          {{ $y := . }}
+          {{ $n := 0 }}{{ range $past }}{{ if eq (substr .start 0 4) $y }}{{ $n = add $n 1 }}{{ end }}{{ end }}
+          <button type="button" class="cal-yr-btn" data-year="{{ $y }}" role="tab" aria-selected="false">
+            {{ $y }}<span class="cal-yr-n">{{ $n }}</span>
+          </button>
+        {{ end }}
+        <button type="button" class="cal-yr-btn" data-year="all" role="tab" aria-selected="false">All</button>
+      </div>
+    </div>
+    {{/* every group ships visible; the script below hides all but one, so the
+         page still reads end-to-end without JS and stays fully indexable */}}
+    {{ range $years }}
+      {{ $y := . }}
+      <div class="cal-yeargroup" data-year="{{ $y }}">
+        <div class="cal-year"><span>{{ $y }}</span></div>
+        {{ range $past }}
+          {{ if eq (substr .start 0 4) $y }}
+            {{ template "cal-card" (dict "ev" . "now" $now "upcoming" false) }}
+          {{ end }}
+        {{ end }}
+      </div>
+    {{ end }}
+  </section>
+  {{ end }}
+</div>
+
+<script>
+  // Year pager for the Past section. Groups render visible so the page works
+  // without JS; this hides all but the selected year and syncs the #YYYY hash.
+  (function () {
+    var btns = Array.prototype.slice.call(document.querySelectorAll('.cal-yr-btn'));
+    var groups = Array.prototype.slice.call(document.querySelectorAll('.cal-yeargroup'));
+    if (!btns.length || !groups.length) { return; }
+
+    var stamps = Array.prototype.slice.call(document.querySelectorAll('.cal-yeargroup .cal-year'));
+
+    function show(year, push) {
+      groups.forEach(function (g) {
+        g.hidden = !(year === 'all' || g.getAttribute('data-year') === year);
+      });
+      // the in-group year chip only earns its place when several years are stacked
+      stamps.forEach(function (s) { s.hidden = year !== 'all'; });
+      btns.forEach(function (b) {
+        var on = b.getAttribute('data-year') === year;
+        b.classList.toggle('is-active', on);
+        b.setAttribute('aria-selected', on ? 'true' : 'false');
+      });
+      if (push) {
+        try {
+          history.replaceState(null, '', year === 'all' ? location.pathname : '#' + year);
+        } catch (e) { /* file:// and the like */ }
+      }
+    }
+
+    btns.forEach(function (b) {
+      b.addEventListener('click', function () { show(b.getAttribute('data-year'), true); });
+    });
+
+    // deep link: /events/calendar/#2023 opens straight on that year
+    var hash = (location.hash || '').replace('#', '');
+    var wanted = /^\d{4}$/.test(hash) &&
+      document.querySelector('.cal-yeargroup[data-year="' + hash + '"]') ? hash : null;
+    show(wanted || btns[0].getAttribute('data-year'), false);
+  })();
+</script>
+{{ end }}
+
+
+{{/* ------------------------------------------------------------------ */}}
+{{ define "cal-card" }}
+{{ $ev := .ev }}
+{{ $start := time.AsTime $ev.start }}
+{{ $end := time.AsTime (default $ev.start $ev.end) }}
+{{ $multi := gt $end.Unix $start.Unix }}
+{{ $sameMonth := and $multi (eq ($start.Format "2006-01") ($end.Format "2006-01")) }}
+
+<article class="cal-card{{ if .upcoming }} is-upcoming{{ end }}">
+  <div class="cal-when" aria-hidden="true">
+    <span class="cal-mon">{{ $start.Format "Jan" }}</span>
+    <span class="cal-day">
+      {{- if $sameMonth }}{{ $start.Format "2" }}–{{ $end.Format "2" }}
+      {{- else }}{{ $start.Format "2" }}{{ end -}}
+    </span>
+    <span class="cal-yr">{{ $start.Format "2006" }}</span>
+  </div>
+
+  <div class="cal-body">
+    <div class="cal-meta">
+      <time datetime="{{ $ev.start }}">
+        {{- if and $multi (not $sameMonth) -}}
+          {{ $start.Format "Jan 2" }} – {{ $end.Format "Jan 2, 2006" }}
+        {{- else if $multi -}}
+          {{ $start.Format "Jan 2" }}–{{ $end.Format "2, 2006" }}
+        {{- else -}}
+          {{ $start.Format "Mon, Jan 2, 2006" }}
+        {{- end -}}
+      </time>
+      <span class="cal-loc">{{ $ev.location }}{{ with $ev.venue }} · {{ . }}{{ end }}</span>
+      {{ if .upcoming }}
+        {{ $days := int (math.Ceil (div (float (sub $start.Unix .now.Unix)) 86400.0)) }}
+        <span class="cal-badge">
+          {{- if le $days 0 }}Happening now
+          {{- else if eq $days 1 }}Tomorrow
+          {{- else }}In {{ $days }} days{{ end -}}
+        </span>
+      {{ end }}
+    </div>
+
+    {{ $ext := false }}
+    {{ with $ev.url }}{{ $ext = hasPrefix . "http" }}{{ end }}
+    <h3 class="cal-title">
+      {{- if $ev.url -}}
+        <a href="{{ $ev.url }}"{{ if $ext }} target="_blank" rel="noopener"{{ end }}>
+          {{- $ev.event }}{{ if $ext }}<span class="cal-ext" aria-hidden="true">↗</span>{{ end -}}
+        </a>
+      {{- else -}}
+        {{ $ev.event }}
+      {{- end -}}
+    </h3>
+
+    {{ with $ev.intro }}<p class="cal-intro">{{ . }}</p>{{ end }}
+
+    <ul class="cal-talks">
+      {{ range $ev.talks }}
+      <li class="cal-talk">
+        <span class="cal-talk-dot" aria-hidden="true"></span>
+        <div class="cal-talk-body">
+          <p class="cal-talk-title">
+            {{- if .url -}}
+              {{ $tExt := hasPrefix .url "http" }}
+              <a href="{{ .url }}"{{ if $tExt }} target="_blank" rel="noopener"{{ end }}>
+                {{- .title }}{{ if $tExt }}<span class="cal-ext" aria-hidden="true">↗</span>{{ end -}}
+              </a>
+            {{- else -}}
+              {{ .title }}
+            {{- end -}}
+          </p>
+          <p class="cal-talk-sub">
+            <span class="cal-speaker">{{ .speaker }}</span>
+            {{ with .date }}<span class="cal-sep">·</span><span>{{ (time.AsTime .).Format "Jan 2" }}</span>{{ end }}
+            {{ with .time }}<span class="cal-sep">·</span><span>{{ . }}</span>{{ end }}
+            {{ with .room }}<span class="cal-sep">·</span><span>{{ . }}</span>{{ end }}
+            {{ with .video }}<a class="cal-link" href="{{ . }}" target="_blank" rel="noopener">Video</a>{{ end }}
+            {{ with .slides }}<a class="cal-link" href="{{ . }}" target="_blank" rel="noopener">Slides</a>{{ end }}
+          </p>
+          {{ with .intro }}<p class="cal-talk-intro">{{ . }}</p>{{ end }}
+        </div>
+      </li>
+      {{ end }}
+    </ul>
+
+    {{ if or $ev.url $ev.recap }}
+    <div class="cal-actions">
+      {{ with $ev.url }}
+      <a class="cal-site" href="{{ . }}"{{ if $ext }} target="_blank" rel="noopener"{{ end }}>
+        {{- if $ext -}}
+          {{ replaceRE `^https?://(www\.)?([^/]+).*$` "$2" . }}<span class="cal-ext" aria-hidden="true">↗</span>
+        {{- else -}}
+          Event page<span class="cal-ext" aria-hidden="true">→</span>
+        {{- end -}}
+      </a>
+      {{ end }}
+      {{ with $ev.recap }}<a class="cal-recap" href="{{ . }}">Read the recap →</a>{{ end }}
+    </div>
+    {{ end }}
+  </div>
+</article>
+{{ end }}

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -11,6 +11,7 @@
     <span class="eyebrow">EVENTS &amp; RELEASES</span>
     <h1>Where the SkyWalking community ships &amp; meets</h1>
     <p>Releases, conference talks, meetups and weekly office hours — newest first.</p>
+    {{ partial "events-tabs.html" (dict "active" "releases") }}
   </div>
 </section>
 

--- a/layouts/partials/events-tabs.html
+++ b/layouts/partials/events-tabs.html
@@ -1,0 +1,16 @@
+{{/*
+  Tab bar shared by the two /events/ views.
+
+  Call with an explicit active key rather than sniffing the URL, so paginated
+  pages (/events/page/2/) still light up the right tab:
+
+    {{ partial "events-tabs.html" (dict "active" "releases") }}
+    {{ partial "events-tabs.html" (dict "active" "calendar") }}
+*/}}
+{{ $active := .active }}
+<nav class="ev-tabs" aria-label="Events views">
+  <a class="ev-tab{{ if eq $active "releases" }} is-active{{ end }}" href="/events/"
+     {{- if eq $active "releases" }} aria-current="page"{{ end }}>Releases &amp; Posts</a>
+  <a class="ev-tab{{ if eq $active "calendar" }} is-active{{ end }}" href="/events/calendar/"
+     {{- if eq $active "calendar" }} aria-current="page"{{ end }}>Community Calendar</a>
+</nav>


### PR DESCRIPTION
## What

`/events/` only tracked releases. This adds a second tab, **Community Calendar**, at `/events/calendar/` — conferences, meetups and summits where SkyWalking committers and community speakers appear, upcoming first and then past by year.

The release timeline is untouched apart from the shared tab bar (a one-line diff in `layouts/events/list.html`). The calendar reads `data/talks.yml` and never reads `content/events/`, so the two never mix.

## Contents

18 events / 59 talks, 2020–2026. Sourced from the conference sites themselves and from the recap posts already in `content/zh/` and `content/blog/` — including tracks not previously listed anywhere on the site: ApacheCon@Home 2021, ApacheCon Asia 2022, CommunityOverCode Asia 2024 and 2025.

Upcoming: Community Over Code Asia 2026 (Beijing, Aug 7–9) and AWS Community Day Hong Kong (Oct 24).

## How it behaves

- **Upcoming vs. past** is computed at build time from the event's end date. Combined with the existing daily cron in `deploy.yaml`, an event moves itself into the past section once it is over — no commit needed.
- **The year pager** builds its buttons and counts from the data. Groups render visible and JS hides all but one, so the page reads end-to-end without JS and stays indexable. `#YYYY` deep-links to a year.
- **Validation**: required fields and date format are asserted in the template. A missing field fails the build with a message naming the event, so a broken entry shows up as a red check here rather than a blank card in production.

## Adding a talk

`data/talks.yml` carries its schema in a comment at the top, and README gains a *Community Calendar* section. A speaker can add a talk entirely in the browser via the **Add your talk** link on the page — no local Hugo setup.

## Notes for review

- Speaker names follow the source. Chinese names carry their pinyin; where a conference lists only an English name it stays English, since romanisation does not reverse. Four Chinese speakers (Cheng Chen, Yihao Chen, Youliang Huang, Zixin Zhou) have no Chinese name recorded anywhere in this repo — safe to fill in if you know them.
- Two conference dates are inferred from post publish dates rather than confirmed against an archived agenda: ApacheCon@Home 2020 (Sep 29 – Oct 1) and COSCon'20 (Oct 25).
- Some session abstracts are condensed from published ones; 23 of 59 talks have none because none was published.

Build passes locally with Hugo 0.159.0. The `.Site.Data` deprecation warning is pre-existing — 15 other layouts use it.