### PR TITLE
Events: add AWS Community Day Shenzhen to the community calendar

### DIFF
--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -929,6 +929,12 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     .cal-speaker { font-weight: 600; color: $body; }
     .cal-sep { color: #c9d2dd; }
   }
+  // delivery language — only rendered where a talk sets it
+  .cal-lang {
+    font-size: 10.5px; font-weight: 700; letter-spacing: .03em;
+    padding: 2px 7px; border-radius: 999px;
+    background: #f2f4f7; color: #5b6573;
+  }
   .cal-talk-intro {
     font-size: 13px; color: $body; line-height: 1.6; margin: 5px 0 0;
     max-width: 68ch;

--- a/data/talks.yml
+++ b/data/talks.yml
@@ -36,6 +36,11 @@
 #     intro     optional  one or two sentences on what the session covers, in the
 #                         same language as the title. Condense the published
 #                         abstract; do not invent one where none exists.
+#     lang      optional  the language the session is delivered in, e.g. "中文" or
+#                         "English". Only worth setting when it is not obvious from
+#                         the title, or when the same talk is given in both — a
+#                         speaker may take one session to two events in different
+#                         languages.
 #     date      optional  "YYYY-MM-DD" when the session day differs from `start`
 #     time      optional  e.g. "13:30 GMT+8"
 #     room      optional
@@ -54,6 +59,21 @@ events:
     talks:
       - title: "Beyond Flat Topologies: Visualizing the Cloud-Native Stack in 3D"
         speaker: 吴晟 Sheng Wu
+        lang: English
+
+  - event: 2026 亚马逊云科技 Community Day · 深圳
+    intro: >-
+      The AWS User Group's annual community conference in Shenzhen, themed "Bridge with Signal · 以价值信号连通现在与未来" — a full day of 20+ community talks across four parallel tracks, run by and for local developers.
+    start: "2026-10-17"
+    location: Shenzhen, China
+    url: https://2026-autumn.awscommunityday.cn/
+    talks:
+      # Same session as AWS Community Day Hong Kong a week later, delivered in Chinese.
+      # The Shenzhen agenda is not published yet, so the title here is the English one
+      # the session is already listed under; swap in the Chinese title once it is out.
+      - title: "Beyond Flat Topologies: Visualizing the Cloud-Native Stack in 3D"
+        speaker: 吴晟 Sheng Wu
+        lang: 中文
 
   - event: Community Over Code Asia 2026
     intro: >-

--- a/layouts/events/calendar.html
+++ b/layouts/events/calendar.html
@@ -237,6 +237,7 @@
           </p>
           <p class="cal-talk-sub">
             <span class="cal-speaker">{{ .speaker }}</span>
+            {{ with .lang }}<span class="cal-lang">{{ . }}</span>{{ end }}
             {{ with .date }}<span class="cal-sep">·</span><span>{{ (time.AsTime .).Format "Jan 2" }}</span>{{ end }}
             {{ with .time }}<span class="cal-sep">·</span><span>{{ . }}</span>{{ end }}
             {{ with .room }}<span class="cal-sep">·</span><span>{{ . }}</span>{{ end }}


### PR DESCRIPTION
Adds **2026 亚马逊云科技 Community Day · 深圳** to `/events/calendar/`.

| | |
|---|---|
| Date | 2026-10-17 (Sat), 09:00–17:00 |
| Location | Shenzhen, China — venue TBA, announced late September |
| Theme | Bridge with Signal · 以价值信号连通现在与未来 |
| Scale | 600+ attendees, 20+ talks, 4 parallel tracks |
| Site | https://2026-autumn.awscommunityday.cn/ |

The 3D cloud-native topology session was accepted here as well as at AWS Community Day Hong Kong a week later — the same talk, delivered in Chinese in Shenzhen and English in Hong Kong.

## New optional `lang` field

To make that distinction visible rather than buried in prose, this adds an optional `lang` on a talk, rendered as a small chip beside the speaker. It only renders where a talk sets it, so all 58 existing talks are untouched — the diff to `data/talks.yml` outside the new event is one line on the Hong Kong session.

## Note for review

The Shenzhen agenda is not published yet (the site's bundle carries no speaker data — the CFP only just closed), so there is no source for a Chinese session title. The entry carries the English title the session is already listed under, with a comment in the data file to swap in the Chinese one once the agenda lands. No title was invented.

Verified: `hugo` builds clean, 19 events / 60 talks, 3 upcoming, Shenzhen sorts ahead of Hong Kong.