### PR TITLE
Feeds: per-language RSS, and an iCalendar feed for the community calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ If a required field is missing, or a date isn't in `YYYY-MM-DD` form, the build 
 with a message naming the offending event — so a broken entry shows up as a failed
 check on the pull request rather than as a blank card on the site.
 
+### Feeds
+
+| Feed | Contents |
+|----|----|
+|`/blog/feed.xml`|English blog|
+|`/zh/feed.xml`|中文博客|
+|`/events/feed.xml`|Releases and events|
+|`/feed.xml`|Combined blog + events|
+|`/events/calendar/index.ics`|Community calendar, subscribable in a calendar app|
+
+RSS is opt-in per section via `outputs` in that section's `_index.md`, not through
+`[outputs] section` in `config.toml`, which would also build a feed for `docs`.
+`rss_sections` and `rss_limit` in `config.toml` control the combined feed and the
+window size. The template is `layouts/_default/list.rss.xml`.
+
+The calendar feed is generated from `data/talks.yml` by
+`layouts/events/calendar.calendar.ics`. Use the `webcal://` link on the calendar
+page to subscribe — downloading the `.ics` imports a snapshot that never updates.
+
 ### Blog
 
 Located at `content/blog`. If you want to create a new blog, you need to create a new subdirectory under this directory. Here is a sample blog below.

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -776,6 +776,26 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   }
 }
 
+// ---------- RSS subscribe link (blog, zh, events heroes) ----------
+.feed-subscribe {
+  display: inline-flex; align-items: center; gap: 7px;
+  margin-top: 18px; padding: 6px 14px;
+  border: 1px solid $line; border-radius: 999px; background: #fff;
+  font-size: 13px; font-weight: 600; color: $body; text-decoration: none;
+  transition: background .16s ease, color .16s ease, border-color .16s ease;
+  svg { color: #e8873a; flex: 0 0 auto; }
+  &:hover { background: #fff7f0; border-color: #f0c9a5; color: #b45f14; }
+}
+.td-events .ev-tabs + .feed-subscribe { margin-top: 14px; margin-left: 12px; }
+.feed-subscribe.is-calendar {
+  svg { color: $brand; }
+  &:hover { background: #eef5fd; border-color: #d6e4f5; color: #2c6cb0; }
+}
+.cal-ics-raw {
+  margin-left: 10px; font-size: 12.5px; color: $muted; text-decoration: none;
+  &:hover { color: $brand; text-decoration: underline; }
+}
+
 // ---------- Events → Community calendar tab ----------
 .td-events {
   .cal-wrap { max-width: 920px; padding-top: 30px; padding-bottom: 64px; }

--- a/config.toml
+++ b/config.toml
@@ -68,6 +68,8 @@ anchor = "smart"
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]
+  # Section feeds are opted into per section in _index.md, not here, which would
+  # also build one for docs.
   section = ["HTML"]
 
 [outputFormats]
@@ -82,6 +84,10 @@ anchor = "smart"
 
 [params]
 copyright = "The Apache Software Foundation"
+
+# /feed.xml carries the English sections; content/zh has its own /zh/feed.xml.
+rss_sections = ["blog", "events"]
+rss_limit = 20
 #qrcode = ""
 #privacy_policy = "https://policies.google.com/privacy"
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Blog"
+outputs: ["HTML", "RSS"]
 linkTitle: "Blog"
 ---
 

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Events"
+outputs: ["HTML", "RSS"]
 linkTitle: "Events"
 ---
 

--- a/content/events/calendar/_index.md
+++ b/content/events/calendar/_index.md
@@ -3,4 +3,5 @@ title: "Community Calendar"
 linkTitle: "Calendar"
 description: "Upcoming and past conference talks, meetups and summits featuring Apache SkyWalking committers and community speakers."
 layout: calendar
+outputs: ["HTML", "CALENDAR"]
 ---

--- a/content/zh/_index.md
+++ b/content/zh/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "博客"
+outputs: ["HTML", "RSS"]
 linkTitle: "博客"
 ---

--- a/layouts/_default/list.rss.xml
+++ b/layouts/_default/list.rss.xml
@@ -1,0 +1,50 @@
+{{- /* Overrides the docsy template: 20 items instead of 50, summaries instead of
+       full bodies (the theme's .Content made the live feed 1.1 MB), and a real
+       <language> per feed — content/zh is a section, not a Hugo language, so it
+       cannot come from .Site.LanguageCode. */ -}}
+{{- $limit := .Site.Params.rss_limit | default 20 -}}
+{{- $isCombined := not .Section -}}
+{{- $pages := slice -}}
+{{- if $isCombined -}}
+  {{- $sections := .Site.Params.rss_sections | default (slice "blog") -}}
+  {{- $pages = first $limit (where .Site.RegularPages "Type" "in" $sections) -}}
+{{- else if .Parent.IsHome -}}
+  {{- $pages = first $limit (where .Site.RegularPages "Type" .Section) -}}
+{{- else -}}
+  {{- $pages = first $limit .Pages -}}
+{{- end -}}
+{{- $lang := cond (in (slice "zh" "zh_tags") .Section) "zh-CN" "en-US" -}}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Site.Title }}{{ if and .Title (ne .Title .Site.Title) }} – {{ .Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ if $isCombined }}Releases, blog posts and community news from Apache SkyWalking{{ else if eq .Section "zh" }}Apache SkyWalking 中文博客{{ else if eq .Section "events" }}Apache SkyWalking releases and community events{{ else }}Recent {{ .Title | lower }} posts from Apache SkyWalking{{ end }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>{{ $lang }}</language>
+    {{- with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>
+    {{- end }}
+    {{- with (index $pages 0) }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ if $isCombined }}{{ .Section | title }}: {{ end }}{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- /* guid must stay stable; changing it re-shows the post as new in every reader */}}
+      <guid>{{ .Permalink }}</guid>
+      {{- with .Params.author }}
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">{{ . | plainify }}</dc:creator>
+      {{- end }}
+      {{- range .Params.tags }}
+      <category>{{ . }}</category>
+      {{- end }}
+      <description>{{ .Description | default (.Summary | plainify | chomp) | truncate 400 }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -15,6 +15,7 @@
     <span class="eyebrow">BLOG</span>
     <h1>Engineering &amp; community notes</h1>
     <p>Release deep-dives, architecture, integrations and field reports from the SkyWalking community — newest first.</p>
+    {{ partial "feed-subscribe.html" (dict "href" "/blog/feed.xml" "label" "Subscribe via RSS") }}
   </div>
 </section>
 

--- a/layouts/events/calendar.calendar.ics
+++ b/layouts/events/calendar.calendar.ics
@@ -1,0 +1,45 @@
+{{- /* iCalendar feed for /events/calendar/, from the same data/talks.yml the page
+       renders. A calendar beats RSS here: RSS announces an item when it is
+       published, a calendar puts it on the day it happens.
+
+       Lines are assembled into a slice and joined with CRLF because RFC 5545
+       requires CRLF line endings throughout, not just at fold points. */ -}}
+{{- $lines := slice
+  "BEGIN:VCALENDAR"
+  "VERSION:2.0"
+  "PRODID:-//Apache SkyWalking//Community Calendar//EN"
+  "CALSCALE:GREGORIAN"
+  "METHOD:PUBLISH"
+  "X-WR-CALNAME:Apache SkyWalking Community Calendar"
+  (partial "ics-fold.txt" (printf "X-WR-CALDESC:%s" (partial "ics-text.txt" "Conference talks, meetups and summits featuring Apache SkyWalking committers and community speakers")))
+  "REFRESH-INTERVAL;VALUE=DURATION:PT12H"
+  "X-PUBLISHED-TTL:PT12H"
+-}}
+{{- $stamp := now.UTC.Format "20060102T150405Z" -}}
+{{- range $ev := .Site.Data.talks.events -}}
+  {{- $start := time.AsTime $ev.start -}}
+  {{- /* DTEND is exclusive for all-day events, so the final day needs +1 */ -}}
+  {{- $end := (time.AsTime (default $ev.start $ev.end)).AddDate 0 0 1 -}}
+  {{- $where := $ev.location -}}
+  {{- with $ev.venue }}{{ $where = printf "%s, %s" . $ev.location }}{{ end -}}
+  {{- $desc := partial "ics-text.txt" $ev.intro -}}
+  {{- range $ev.talks -}}
+    {{- $desc = printf "%s\\n\\n%s" $desc (partial "ics-text.txt" (printf "%s — %s" .title .speaker)) -}}
+  {{- end -}}
+  {{- $lines = $lines
+    | append "BEGIN:VEVENT"
+    | append (printf "UID:%s@skywalking.apache.org" (md5 (printf "%s|%s" $ev.start $ev.event)))
+    | append (printf "DTSTAMP:%s" $stamp)
+    | append (printf "DTSTART;VALUE=DATE:%s" ($start.Format "20060102"))
+    | append (printf "DTEND;VALUE=DATE:%s" ($end.Format "20060102"))
+    | append (partial "ics-fold.txt" (printf "SUMMARY:%s" (partial "ics-text.txt" $ev.event)))
+    | append (partial "ics-fold.txt" (printf "LOCATION:%s" (partial "ics-text.txt" $where)))
+  -}}
+  {{- with $ev.url }}{{ $lines = $lines | append (partial "ics-fold.txt" (printf "URL:%s" (. | absURL))) }}{{ end -}}
+  {{- $lines = $lines
+    | append (partial "ics-fold.txt" (printf "DESCRIPTION:%s" $desc))
+    | append "END:VEVENT"
+  -}}
+{{- end -}}
+{{- $lines = $lines | append "END:VCALENDAR" -}}
+{{- delimit $lines "\r\n" -}}

--- a/layouts/events/calendar.html
+++ b/layouts/events/calendar.html
@@ -63,6 +63,10 @@
       speakers. Speaking about SkyWalking somewhere?
       <a href="https://github.com/apache/skywalking-website/edit/master/data/talks.yml">Add your talk</a>.</p>
     {{ partial "events-tabs.html" (dict "active" "calendar") }}
+    {{- with .OutputFormats.Get "CALENDAR" }}
+    {{ partial "feed-subscribe.html" (dict "href" .Permalink "label" "Subscribe in your calendar" "icon" "calendar") }}
+    <a class="cal-ics-raw" href="{{ .RelPermalink }}">or download .ics</a>
+    {{- end }}
   </div>
 </section>
 

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -12,6 +12,7 @@
     <h1>Where the SkyWalking community ships &amp; meets</h1>
     <p>Releases, conference talks, meetups and weekly office hours — newest first.</p>
     {{ partial "events-tabs.html" (dict "active" "releases") }}
+    {{ partial "feed-subscribe.html" (dict "href" "/events/feed.xml" "label" "Subscribe via RSS") }}
   </div>
 </section>
 

--- a/layouts/partials/feed-subscribe.html
+++ b/layouts/partials/feed-subscribe.html
@@ -1,0 +1,19 @@
+{{- /* {{ partial "feed-subscribe.html" (dict "href" "/blog/feed.xml" "label" "Subscribe via RSS") }}
+       Pass "icon" "calendar" for an .ics/webcal link; defaults to the RSS mark. */ -}}
+{{- /* safeURL because Go's sanitiser rejects the webcal:// scheme; every caller
+       passes a site-controlled URL. */ -}}
+<a class="feed-subscribe{{ if eq (.icon | default "rss") "calendar" }} is-calendar{{ end }}" href="{{ .href | safeURL }}" title="{{ .label }}">
+  {{- if eq (.icon | default "rss") "calendar" }}
+  <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="2">
+    <rect x="3" y="5" width="18" height="16" rx="2"/>
+    <path d="M3 10h18M8 3v4M16 3v4" stroke-linecap="round"/>
+  </svg>
+  {{- else }}
+  <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true" focusable="false">
+    <circle cx="5.5" cy="18.5" r="2.5" fill="currentColor"/>
+    <path d="M3 10.5a10.5 10.5 0 0 1 10.5 10.5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+    <path d="M3 3.5A17.5 17.5 0 0 1 20.5 21" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+  </svg>
+  {{- end }}
+  <span>{{ .label }}</span>
+</a>

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -5,3 +5,4 @@
        where the site's SEO metadata is emitted, so the theme itself stays unforked. */ -}}
 {{ partial "seo/meta.html" . }}
 {{ partial "seo/schema.html" . }}
+{{ partial "seo/feeds.html" . }}

--- a/layouts/partials/ics-fold.txt
+++ b/layouts/partials/ics-fold.txt
@@ -1,0 +1,23 @@
+{{- /* Folds one content line to 75 octets (RFC 5545 §3.1), splitting only on rune
+       boundaries so a multi-byte character is never cut in half.
+
+       The limit is octets, but Hugo's `len` counts runes, so the UTF-8 width of
+       each rune is derived from its code point range instead. */ -}}
+{{- $out := "" -}}
+{{- $used := 0 -}}
+{{- range $r := split . "" -}}
+  {{- $w := 4 -}}
+  {{- if findRE `^[\x{00}-\x{7F}]$` $r -}}{{- $w = 1 -}}
+  {{- else if findRE `^[\x{80}-\x{7FF}]$` $r -}}{{- $w = 2 -}}
+  {{- else if findRE `^[\x{800}-\x{FFFF}]$` $r -}}{{- $w = 3 -}}
+  {{- end -}}
+  {{- if gt (add $used $w) 75 -}}
+    {{- /* the leading space of a continuation line counts toward its 75 */ -}}
+    {{- $out = printf "%s\r\n %s" $out $r -}}
+    {{- $used = add 1 $w -}}
+  {{- else -}}
+    {{- $out = printf "%s%s" $out $r -}}
+    {{- $used = add $used $w -}}
+  {{- end -}}
+{{- end -}}
+{{- $out -}}

--- a/layouts/partials/ics-text.txt
+++ b/layouts/partials/ics-text.txt
@@ -1,0 +1,8 @@
+{{- /* Escapes a value for an iCalendar TEXT field (RFC 5545 §3.3.11).
+       Backslash must be escaped first, or it would double-escape the others. */ -}}
+{{- $s := . | plainify -}}
+{{- $s = replaceRE `\\` `\\\\` $s -}}
+{{- $s = replaceRE `;` `\;` $s -}}
+{{- $s = replaceRE `,` `\,` $s -}}
+{{- $s = replaceRE `\r?\n` `\n` $s -}}
+{{- chomp $s -}}

--- a/layouts/partials/seo/feeds.html
+++ b/layouts/partials/seo/feeds.html
@@ -1,0 +1,15 @@
+{{- /* docsy's head.html already links the current page's own feed, so this only
+       fills the gaps: the section feed on pages inside a section (posts, the
+       calendar), and the site-wide feed anywhere but the home page. */ -}}
+{{- $sectionFeed := "" -}}
+{{- with .FirstSection -}}
+  {{- if and (not .IsHome) (ne $.RelPermalink .RelPermalink) -}}
+    {{- $sectionFeed = .OutputFormats.Get "RSS" -}}
+  {{- end -}}
+{{- end -}}
+{{- with $sectionFeed }}
+<link rel="alternate" type="application/rss+xml" href="{{ .Permalink }}" title="{{ $.FirstSection.Title }} — {{ $.Site.Title }}">
+{{- end }}
+{{- if not .IsHome }}{{ with .Site.Home.OutputFormats.Get "RSS" }}
+<link rel="alternate" type="application/rss+xml" href="{{ .Permalink }}" title="{{ $.Site.Title }}">
+{{- end }}{{ end }}

--- a/layouts/zh/list.html
+++ b/layouts/zh/list.html
@@ -14,6 +14,7 @@
     <span class="eyebrow">中文博客</span>
     <h1>工程实践与社区动态</h1>
     <p>来自 Apache SkyWalking 社区的版本解读、架构设计、集成实践与一线经验分享 —— 按时间倒序排列。</p>
+    {{ partial "feed-subscribe.html" (dict "href" "/zh/feed.xml" "label" "RSS 订阅") }}
   </div>
 </section>
 


### PR DESCRIPTION
The site had exactly one feed — `/feed.xml`, blog posts only. Nothing on the site linked it, and no page declared autodiscovery, so a reader handed a page URL could not resolve it. The path is `feed.xml` rather than the conventional `index.xml`, so it could not be guessed either. In practice it was unreachable.

## Feeds after this change

| Feed | Contents | `<language>` |
|---|---|---|
| `/blog/feed.xml` | English blog | `en-US` |
| `/zh/feed.xml` | 中文博客 | `zh-CN` |
| `/events/feed.xml` | Releases and events | `en-US` |
| `/feed.xml` | Combined blog + events | `en-US` |
| `/events/calendar/index.ics` | Community calendar | — |

**Chinese and English are separate feeds** with a correct `<language>`. `content/zh` is a section rather than a Hugo language, so this cannot come from `.Site.LanguageCode` and is derived from the section; the `zh_tags/*` feeds get it too.

**Size: 1.1 MB → ~16 KB.** The docsy template emitted full `.Content` per item. This emits the front-matter description, falling back to an auto-summary, and carries 20 items rather than 50 — which covers ~3 months in every section here, comfortably longer than any plausible gap between a reader's polls.

**RSS is opt-in per section** via `outputs` in each `_index.md`, deliberately not `[outputs] section` in `config.toml`, which would also have built a feed for `docs`.

**Autodiscovery** goes through the existing `seo` hook. docsy's `head.html` already links a page's own feed, so `layouts/partials/seo/feeds.html` only fills gaps — the section feed on posts and on the calendar, the site-wide feed everywhere but home. Verified no page emits a duplicate URL.

## Calendar gets iCalendar, not RSS

RSS announces an item when it is *published*; a calendar places it on the day it *happens*. An upcoming talk in an RSS feed would appear the day it was added and never again, which is backwards.

The `.ics` is generated from the same `data/talks.yml` the page renders. The page offers a `webcal://` link — a live subscription that refreshes on its own — alongside a plain `.ics` download, which imports a snapshot that never updates.

Validated against the output, not assumed:

| Check | Result |
|---|---|
| Lines > 75 octets (RFC 5545 folding) | 0 |
| CRLF line endings throughout | yes |
| HTML entities leaked into output | 0 |
| VEVENTs vs events in `talks.yml` | 19 / 19 |
| UIDs unique and stable | yes |
| SUMMARY round-trips through RFC unfolding | all 19 |
| `DTEND` exclusivity | COC Asia 2026 → `20260807`–`20260810` for a 7–9 Aug event |

Two bugs surfaced doing that, both fixed: the escaping partials were named `.html`, so Hugo parsed them as HTML templates and emitted `&amp;#39;` mid-feed; and folding initially left 23 over-long lines because Hugo's `len` counts runes rather than bytes, so the fold partial now derives exact UTF-8 width from the code point range.

## Worth knowing

- **`/feed.xml` changes contents** — blog-only before, blog + events now. Anyone already subscribed starts receiving releases. Given nothing linked it, the subscriber count is likely near zero, but it is a behaviour change.
- **Tag feeds already existed** (`/tags/release/feed.xml` etc. return 200 on production today — Hugo taxonomy defaults). This PR does not add them; they inherit the smaller format.

`hugo` builds clean. README documents the feeds and how sections opt in.