### PR TITLE
Release Apache SkyWalking Java Agent 9.7.0

### DIFF
--- a/content/events/release-apache-skywalking-java-agent-9-6-0/index.md
+++ b/content/events/release-apache-skywalking-java-agent-9-6-0/index.md
@@ -26,4 +26,4 @@ Changes by Version
 * Add JDK25 plugin tests for Spring 6.
 * Ignore classes starting with "sun.nio.cs" in bytebuddy due to potential class loading deadlock.
 
-All issues and pull requests are [here](https://github.com/apache/skywalking-java/milestone/10?closed=1)
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/242?closed=1)

--- a/content/events/release-apache-skywalking-java-agent-9-7-0/index.md
+++ b/content/events/release-apache-skywalking-java-agent-9-7-0/index.md
@@ -1,0 +1,42 @@
+---
+title: Release Apache SkyWalking Java Agent 9.7.0
+date: 2026-08-14
+author: SkyWalking Team
+description: "Release Apache SkyWalking Java Agent 9.7.0."
+---
+
+SkyWalking Java Agent 9.7.0 is released. Go to [downloads](/downloads) page to find release tars.
+Changes by Version
+
+9.7.0
+------------------
+
+* Fix `plugin.http.include_http_headers` not working on Spring Boot 3.x / Jakarta EE (apache/skywalking#13938).
+* Support `plugin.http.include_http_headers` in the Tomcat plugin, collecting the configured request headers as the `http.headers` tag on Tomcat entry spans (e.g. RESTEasy on Tomcat), consistent with the Spring MVC plugin. Honors the shared `plugin.http.http_headers_length_threshold`.
+* Unify the Tomcat plugins into a single `tomcat` plugin (Tomcat 7 - 10) and the Jetty server plugins into a single `jetty-server` plugin (Jetty 9 - 11), each supporting both `javax.servlet` and `jakarta.servlet`. Breaking change: plugin names `tomcat-7.x/8.x` and `tomcat-10.x` are replaced by `tomcat`, and `jetty-server-9.x` and `jetty-server-11.x` by `jetty-server`; update `plugin.exclude_plugins` if you reference the old names.
+* Add a Jetty 12 server plugin (`jetty-server-12.x`). Jetty 12 removed the `HttpChannel` handle target and moved request handling to the async `Server#handle(Request, Response, Callback)` core API, so it needs a separate plugin from the merged `jetty-server`.
+* Add a Struts 7 plugin (`struts2-7.x`) for Jakarta Struts, whose `DefaultActionInvocation` moved to `org.apache.struts2`.
+* Added support for Lettuce reactive Redis commands.
+* Add tracing support for `invokeAll` and `invokeAny` in the JDK thread pool plugin (`jdk-threadpool-plugin`).
+* Add Spring AI 1.x plugin and GenAI layer.
+* Add tracing support for vector-store retrieval operations.
+* Fix httpclient-5.x plugin injecting sw8 propagation headers into ClickHouse HTTP requests (port 8123), causing HTTP 400. Add `PROPAGATION_EXCLUDE_PORTS` config to skip tracing (including header injection) for specified ports in the classic client interceptor.
+* Add Spring RabbitMQ 2.x - 4.x plugin.
+* Extend MySQL plugin to support MySQL Connector/J 8.4.0 and 9.x (9.0 -> 9.6).
+* Extend MariaDB plugin to support MariaDB Connector/J 2.7.x.
+* Add MariaDB 3.x plugin (all classes renamed in 3.x).
+* Extend MongoDB 4.x plugin to support MongoDB Java Driver 4.2 -> 4.10. Fix db.bind_vars extraction for driver 4.9+ where InsertOperation/DeleteOperation/UpdateOperation classes were removed.
+* Fix MongoDB 4.x plugin for driver 4.11+ where Cluster.getDescription() was removed, use getCurrentDescription() instead.
+* Extend Feign plugin to support OpenFeign 10.x, 11.x, 12.1.
+* Add Feign 12.2+ PathVar support (BuildTemplateByResolvingArgs moved to RequestTemplateFactoryResolver).
+* Extend Undertow plugin to support Undertow 2.1.x, 2.2.x, 2.3.x.
+* Extend GraphQL plugin to support graphql-java 18 -> 24 (20+ requires JDK 17).
+* Extend Spring Kafka plugin to support Spring Kafka 2.4 -> 2.9 and 3.0 -> 3.3.
+* Extend Jedis 4.x plugin to support Jedis 5.x (fix witness method for 5.x compatibility).
+* Add Elasticsearch Java client (co.elastic.clients:elasticsearch-java) plugin for 7.16.x-9.x.
+* Fix an issue where `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` was not honored by clickhouse-0.3.1 and clickhouse-0.3.2.x plugins.
+* Fix agent lifecycle events: the Start event now carries the service instance name, and the Shutdown event is delivered on graceful JVM exit. `ServiceManager` prepares/starts higher-priority `BootService`s first and shuts them down last (matching `BootService#priority()`), and the shutdown event refreshes its gRPC deadline before sending.
+* Fix the `SenderSendInterceptor` in the nutz-plugins/http-1.x-plugin to avoid NPE caused by the Response status.
+* Only publish `apm-application-toolkit` modules to Maven Central. Agent and plugins are distributed via download package and Docker images.
+
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/249?closed=1)

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -130,7 +130,10 @@
           link: /docs/skywalking-java/next/readme/
         - version: Latest
           link: /docs/skywalking-java/latest/readme/
-          commitId: 8c649c4d249cce327474fd117bb81ed48378e535
+          commitId: 7a6c1e46c9c8ee7f26988caf57c5023c1ff4fb42
+        - version: v9.7.0
+          link: /docs/skywalking-java/v9.7.0/readme/
+          commitId: 7a6c1e46c9c8ee7f26988caf57c5023c1ff4fb42
         - version: v9.6.0
           link: /docs/skywalking-java/v9.6.0/readme/
           commitId: 8c649c4d249cce327474fd117bb81ed48378e535

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -322,15 +322,24 @@
       icon: java-agent
       description: The Java Agent for Apache SkyWalking, which provides the native tracing/metrics/logging/event/profiling abilities for Java projects.
       source:
+        - version: 9.7.0
+          date: Aug. 14th, 2026
+          downloadLink:
+            - name: src
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/java-agent/9.7.0/apache-skywalking-java-agent-9.7.0-src.tgz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/java-agent/9.7.0/apache-skywalking-java-agent-9.7.0-src.tgz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/java-agent/9.7.0/apache-skywalking-java-agent-9.7.0-src.tgz.sha512
         - version: 9.6.0
           date: Feb. 16th, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0-src.tgz
+              link: https://archive.apache.org/dist/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0-src.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0-src.tgz.asc
+              link: https://archive.apache.org/dist/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0-src.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0-src.tgz.sha512
+              link: https://archive.apache.org/dist/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0-src.tgz.sha512
         - version: 9.5.0
           date: Aug. 18th, 2025
           downloadLink:
@@ -386,15 +395,24 @@
             - name: sha512
               link: https://archive.apache.org/dist/skywalking/java-agent/9.0.0/apache-skywalking-java-agent-9.0.0-src.tgz.sha512
       distribution:
+        - version: v9.7.0
+          date: Aug. 14th, 2026
+          downloadLink:
+            - name: tar
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/java-agent/9.7.0/apache-skywalking-java-agent-9.7.0.tgz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/java-agent/9.7.0/apache-skywalking-java-agent-9.7.0.tgz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/java-agent/9.7.0/apache-skywalking-java-agent-9.7.0.tgz.sha512
         - version: v9.6.0
           date: Feb. 16th, 2026
           downloadLink:
             - name: tar
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0.tgz
+              link: https://archive.apache.org/dist/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0.tgz.asc
+              link: https://archive.apache.org/dist/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0.tgz.sha512
+              link: https://archive.apache.org/dist/skywalking/java-agent/9.6.0/apache-skywalking-java-agent-9.6.0.tgz.sha512
         - version: v9.5.0
           date: Aug. 18th, 2025
           downloadLink:


### PR DESCRIPTION
Website updates for the Java Agent 9.7.0 release ([GitHub release](https://github.com/apache/skywalking-java/releases/tag/v9.7.0), published 2026-08-14).

### Changes

- **New event post** `content/events/release-apache-skywalking-java-agent-9-7-0/index.md` — user-facing changelog from `CHANGES.md` at the `v9.7.0` tag. Excludes the test-only (`test/plugin/run.sh`) and build-only (release script) entries per the usual convention.
- **`data/releases.yml`** — 9.7.0 added at the top of both `source` and `distribution`, using `closer.cgi` / `downloads.apache.org`; 9.6.0's links demoted to `archive.apache.org`.
- **`data/docs.yml`** — `Latest` and a new `v9.7.0` entry both set to `7a6c1e46c9c8ee7f26988caf57c5023c1ff4fb42`, the dereferenced `v9.7.0` tag commit.
- **Drive-by fix** — the 9.6.0 post linked `skywalking-java/milestone/10`, which is the 9.0.0 milestone. Corrected to `skywalking/milestone/242` ("Java - 9.6.0"), matching its `CHANGES.md` and every other Java release post.

### Note before merging

The Apache dist mirror has not synced 9.7.0 yet — `downloads.apache.org/skywalking/java-agent/` still tops out at 9.6.0. The new `closer.cgi` and `downloads.apache.org` links will 404 until the artifacts are published to dist.