### PR TITLE
Host the NodeJS Agent docs on the website

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -178,10 +178,16 @@
       description: The NodeJS Agent for Apache SkyWalking, which provides the native tracing abilities for NodeJS projects.
       user: apache
       repo: skywalking-nodejs
+      repoUrl: https://github.com/apache/skywalking-nodejs.git
       docs:
-        - version: 0.9.0
-          link: https://github.com/apache/skywalking-nodejs/tree/v0.9.0
-          commitId: 1524588c5e2023e6dacf146cf39c671453bf78c2
+        - version: Next
+          link: /docs/skywalking-nodejs/next/readme/
+        - version: Latest
+          link: /docs/skywalking-nodejs/latest/readme/
+          commitId: bf5dc68ed6e36254aed2aa55abe5f72ba12bddc3
+        - version: v0.9.0
+          link: /docs/skywalking-nodejs/v0.9.0/readme/
+          commitId: bf5dc68ed6e36254aed2aa55abe5f72ba12bddc3
     - name: Go Agent
       icon: skywalking-go
       description: The Go Agent for Apache SkyWalking, which provides the native tracing/metrics/logging abilities for Golang projects.


### PR DESCRIPTION
`skywalking-nodejs` moved its user documentation into `docs/` with a `menu.yml` (apache/skywalking-nodejs#145), so the agent can render on the site like every other Hugo-hosted component instead of linking out to a GitHub tree.

### Entries

| Version | commitId | Source |
| --- | --- | --- |
| `Next` | — | `master` (0.10.0-dev) |
| `Latest` | `bf5dc68` | tip of `0.9.0-docs` |
| `v0.9.0` | `bf5dc68` | tip of `0.9.0-docs` |

`bf5dc68` sits on the `0.9.0-docs` branch, which is the `v0.9.0` tag commit (`1524588`, confirmed ancestor) plus the docs move. A follow-up commit there removes what landed after the release — the Node.js runtime metrics page, the `SW_AGENT_*RUNTIME_METRICS*` options, the comma-separated backend-address claim — so the snapshot documents the agent users actually run rather than master. `Latest` and `v0.9.0` share a commitId, which is what lets `seo/doc-canonical-map.html` canonicalise the tagged tree to `/latest/`.

### Why the old GitHub-tree entry is gone rather than kept alongside

It cannot coexist with `repoUrl`, for two independent reasons:

- `repoUrl` is item-level and `docs.js` does `if (!repoUrl) continue;` *inside* the per-entry loop, so every entry gets run through `doc.sh`. An external-link entry yields `localPath = /content/https://github.com/…` and then fails at `cp ./docs/menu.yml`, which under `set -o errexit` kills the whole build.
- The version switcher in `layouts/projectdoc/baseof.html` builds its target by substituting the slug into the current `/docs/<repo>/<version>/…` path, so it cannot navigate to github.com — the option would 404, then 404 again on its `/readme/` fallback.

Nothing is lost: at the `v0.9.0` tag, `docs/` contained only `How-to-release.md` (all user docs were in the root `README.md`), and the docs card footer already links to the repository.

### Verification

Full `npm run docs && hugo` locally, both exit 0 — 5421 pages, no errors:

```
next     15 pages  runtime-metrics tracing
latest   14 pages  tracing
v0.9.0   14 pages  tracing
```

`runtime-metrics` appears only under `next`, confirming the 0.9.0 snapshot is correctly scoped.

### One thing to watch

`bf5dc68` is reachable only as the tip of the `0.9.0-docs` branch. `doc.sh` fetches it by bare SHA, so deleting or force-pushing that branch would break the site build. Worth keeping the branch, or tagging the commit so it stays reachable independently.