### PR TITLE
Archive the BanyanDB Java Client

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -392,16 +392,6 @@
       docs:
         - version: Next
           link: https://github.com/apache/skywalking-banyandb-client-proto/blob/main/README.md
-    - name: BanyanDB Java Client
-      icon: banyan-db
-      description: The client implementation for SkyWalking BanyanDB in Java
-      user: apache
-      repo: skywalking-banyandb-java-client
-      docs:
-        - version: Next
-          link: https://github.com/apache/skywalking-banyandb-java-client/blob/main/README.md
-        - version: v0.9.1
-          link: https://github.com/apache/skywalking-banyandb-java-client/blob/v0.9.1/README.md
     - name: BanyanDB Helm
       icon: banyan-db
       description: BanyanDB Helm Chart repository provides ways to install and configure BanyanDB in a Kubernetes cluster.
@@ -469,6 +459,10 @@
       description: Observability Analysis Language(OAL) Tool is a code generation tool for SkyWalking. From Nov. 6th 2018, merged into main codebase.
       user: apache
       repo: skywalking-oal-tool
+    - name: (Archived) BanyanDB Java Client
+      description: The client implementation for SkyWalking BanyanDB in Java. Deprecated — BanyanDB clients, including the OAP server, use the BanyanDB Client Proto directly.
+      user: apache
+      repo: skywalking-banyandb-java-client
 - type: Ecosystem
   list:
     - name:

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -859,25 +859,6 @@
               link: https://downloads.apache.org/skywalking/banyandb/0.10.3/skywalking-banyandb-0.10.3-bydbctl.tgz.asc
             - name: sha512
               link: https://downloads.apache.org/skywalking/banyandb/0.10.3/skywalking-banyandb-0.10.3-bydbctl.tgz.sha512
-    - name: BanyanDB Java Client
-      icon: banyan-db
-      description: The client implementation for SkyWalking BanyanDB in Java
-      source:
-        - version: v0.9.1
-          date: Oct 15th , 2025
-          downloadLink:
-            - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb-java-client/0.9.1/apache-skywalking-banyandb-java-client-0.9.1-src.tgz
-            - name: asc
-              link: https://downloads.apache.org/skywalking/banyandb-java-client/0.9.1/apache-skywalking-banyandb-java-client-0.9.1-src.tgz.asc
-            - name: sha512
-              link: https://downloads.apache.org/skywalking/banyandb-java-client/0.9.1/apache-skywalking-banyandb-java-client-0.9.1-src.tgz.sha512
-      distribution:
-        - version: v0.9.1
-          date: Oct 15th , 2025
-          downloadLink:
-            - name: Install via maven
-              link: https://search.maven.org/artifact/org.apache.skywalking/banyandb-java-client/0.9.1/jar
     - name: BanyanDB Helm
       icon: banyan-db
       description: BanyanDB Helm repository provides ways to install and configure BanyanDB. The scripts are written in Helm 3.
@@ -942,3 +923,24 @@
             - name: sha512
               link: https://downloads.apache.org/skywalking/infra-e2e/1.3.0/skywalking-e2e-1.3.0-bin.tgz.sha512
 - type: Archived Releases
+  description: These components are no longer developed or released. The artifacts below stay available on archive.apache.org for existing users.
+  list:
+    - name: BanyanDB Java Client
+      icon: banyan-db
+      description: The client implementation for SkyWalking BanyanDB in Java. Deprecated — BanyanDB clients, including the OAP server, use the BanyanDB Client Proto directly.
+      source:
+        - version: v0.9.1
+          date: Oct. 15th, 2025
+          downloadLink:
+            - name: src
+              link: https://archive.apache.org/dist/skywalking/banyandb-java-client/0.9.1/apache-skywalking-banyandb-java-client-0.9.1-src.tgz
+            - name: asc
+              link: https://archive.apache.org/dist/skywalking/banyandb-java-client/0.9.1/apache-skywalking-banyandb-java-client-0.9.1-src.tgz.asc
+            - name: sha512
+              link: https://archive.apache.org/dist/skywalking/banyandb-java-client/0.9.1/apache-skywalking-banyandb-java-client-0.9.1-src.tgz.sha512
+      distribution:
+        - version: v0.9.1
+          date: Oct. 15th, 2025
+          downloadLink:
+            - name: Install via maven
+              link: https://search.maven.org/artifact/org.apache.skywalking/banyandb-java-client/0.9.1/jar


### PR DESCRIPTION
The BanyanDB Java Client is deprecated — BanyanDB clients, including the OAP server, use the BanyanDB Client Proto directly, so there is nothing further to release.

### Changes

**`data/docs.yml`** — moved out of *Database* into *Archived Repositories* as `(Archived) BanyanDB Java Client`. The README doc links are dropped so the card matches the other archived repositories (bare card linking to the repo, no "Read docs →").

**`data/releases.yml`** — moved v0.9.1 into *Archived Releases*, with `src`/`asc`/`sha512` repointed at `archive.apache.org`. `downloads.apache.org` only carries current releases, and this component will not have another one; all three archive URLs verified 200. Maven coordinates unchanged. Also corrected the `Oct 15th , 2025` date to the `Mon. DDth, YYYY` form used everywhere else.

### Why the Archived Releases section looked broken

This is the second issue in the report. `- type: Archived Releases` was added to `releases.yml` as a bare header with **no `list:`**, and nothing was ever moved into it. The chip loop in `layouts/downloads/list.html` and the `<h2>` in `layouts/shortcodes/downloads-block.html` both render unconditionally, so the live page has been emitting:

```html
<h2 class="dl-cat" id="ArchivedReleases">Archived Releases</h2>
<div class="dl-grid">
</div>
```

— a heading and a chip that jump to an empty grid, which reads as a missing section. It now has its first entry. (If you'd like a hard guard so a future empty category can't render a dead chip and heading again, that's a small change in those two templates — say the word and I'll add it.)

### Verification

Local Hugo build, 5421 pages, no errors:

| | |
| --- | --- |
| Downloads → Archived Releases | 1 card `BanyanDBJavaClient`, v0.9.1 source + distribution, 3 archive.apache.org links |
| Downloads → Database | `BanyanDB Server (BanyanD)`, `BanyanDB Command Line Tool (bydbctl)`, `BanyanDB Helm` |
| Docs → Database | `BanyanDB`, `BanyanDB Client Proto`, `BanyanDB Helm` |
| Docs → Archived | …`(Archived) OAL Generator`, `(Archived) BanyanDB Java Client` |
| "Latest releases" sidebar | unaffected |

The card keeps its `BanyanDBJavaClient` id, so existing links to `/downloads/#BanyanDBJavaClient` still resolve — they now land in Archived Releases.

### Not done here

The GitHub repo itself still reports `archived=false`. Flipping that flag is a separate action on `apache/skywalking-banyandb-java-client`.