### PR TITLE
Downloads: restore the archive links, fold archived releases to the bottom

### DIFF
--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -1498,6 +1498,31 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     p { margin: 0; }
     a { color: $brand; text-decoration: underline; }
   }
+  // archived categories: folded shut, visually stepped back from live releases
+  .dl-chip--muted { color: $muted; }
+
+  .dl-archived {
+    margin: 44px 0 0; padding-top: 22px; border-top: 1px solid $line; scroll-margin-top: 80px;
+
+    > summary {
+      display: flex; align-items: baseline; gap: 10px; cursor: pointer;
+      list-style: none; user-select: none;
+      &::-webkit-details-marker { display: none; }
+      &::before {
+        content: ""; flex: none; width: 7px; height: 7px; margin-right: 2px;
+        border-right: 2px solid $muted; border-bottom: 2px solid $muted;
+        transform: rotate(-45deg); transition: transform .15s ease;
+      }
+      &:hover .dl-archived-title { color: $brand; }
+    }
+    &[open] > summary::before { transform: rotate(45deg); }
+
+    .dl-archived-title { font-size: 18px; font-weight: 700; color: $body; }
+    .dl-archived-count { font-size: 13px; color: $muted; }
+    .dl-archived-body { padding-top: 16px; }
+    .dl-cat-note { margin-top: 0; }
+  }
+
   .dl-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; grid-auto-rows: 1fr; }
   .dl-grid--docker { grid-template-columns: repeat(4, 1fr); grid-auto-rows: 1fr; }
 

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -1493,6 +1493,11 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     font-size: 22px; font-weight: 700; color: $ink; border: 0; padding: 0;
     margin: 32px 0 16px; scroll-margin-top: 80px;
   }
+  .dl-cat-note {
+    max-width: 900px; margin: -6px 0 16px; color: $body; font-size: 14px; line-height: 1.6;
+    p { margin: 0; }
+    a { color: $brand; text-decoration: underline; }
+  }
   .dl-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; grid-auto-rows: 1fr; }
   .dl-grid--docker { grid-template-columns: repeat(4, 1fr); grid-auto-rows: 1fr; }
 

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -923,6 +923,7 @@
             - name: sha512
               link: https://downloads.apache.org/skywalking/infra-e2e/1.3.0/skywalking-e2e-1.3.0-bin.tgz.sha512
 - type: Archived Releases
+  archived: true
   description: >-
     Older releases are not maintained and are not recommended for new users, but their source
     code and binaries are still available if you have a specific reason to need them. Every

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -923,7 +923,14 @@
             - name: sha512
               link: https://downloads.apache.org/skywalking/infra-e2e/1.3.0/skywalking-e2e-1.3.0-bin.tgz.sha512
 - type: Archived Releases
-  description: These components are no longer developed or released. The artifacts below stay available on archive.apache.org for existing users.
+  description: >-
+    Older releases are not maintained and are not recommended for new users, but their source
+    code and binaries are still available if you have a specific reason to need them. Every
+    SkyWalking release is kept in the
+    [Archive repository](https://archive.apache.org/dist/skywalking/), and the
+    [Archive incubating repository](https://archive.apache.org/dist/incubator/skywalking/)
+    holds the releases made while SkyWalking was an incubator project. The components below
+    are no longer developed or released at all.
   list:
     - name: BanyanDB Java Client
       icon: banyan-db

--- a/layouts/downloads/baseof.html
+++ b/layouts/downloads/baseof.html
@@ -18,6 +18,24 @@
 {{ partial "active-scripts.html" . }}
 {{ partial "scripts.html" . }}
 <script>
+  // A folded archived category must still open when something inside it is
+  // linked directly, e.g. /downloads/#BanyanDBJavaClient or its own chip.
+  function openTargetDetails() {
+    var hash = location.hash;
+    if (!hash || hash.length < 2) return;
+    var el;
+    try { el = document.querySelector(hash); } catch (e) { return; }
+    if (!el) return;
+    var d = el.closest('details');
+    while (d) {
+      d.open = true;
+      d = d.parentElement ? d.parentElement.closest('details') : null;
+    }
+    el.scrollIntoView();
+  }
+  window.addEventListener('hashchange', openTargetDetails);
+  openTargetDetails();
+
   $('.download-wrapper').on('click', function (e) {
     var label = $(e.target).data('label')
     if (label) {

--- a/layouts/downloads/list.html
+++ b/layouts/downloads/list.html
@@ -9,11 +9,20 @@
            container images and Helm charts are provided too — always verify downloads against the
            <span class="dl-mono">.asc</span> and <span class="dl-mono">.sha512</span> signatures.</p>
         <div class="dl-chips">
+          {{- /* Archived categories are chipped last, after Docker, matching
+                 the order they render in downloads-block.html. */ -}}
           {{ range .Site.Data.releases }}
+          {{ if not .archived }}
           {{ $cat := or .buttonText (replace .type " " "") }}
           <a class="dl-chip" href="#{{ $cat }}">{{ .type }}</a>
           {{ end }}
+          {{ end }}
           <a class="dl-chip" href="#DockerImages">Docker images</a>
+          {{ range .Site.Data.releases }}
+          {{ if .archived }}
+          <a class="dl-chip dl-chip--muted" href="#{{ or .buttonText (replace .type " " "") }}">{{ .type }}</a>
+          {{ end }}
+          {{ end }}
         </div>
       </div>
       <aside class="dl-latest">
@@ -24,6 +33,7 @@
         {{ $mon := dict "Jan" 1 "Feb" 2 "Mar" 3 "Apr" 4 "May" 5 "Jun" 6 "Jul" 7 "Aug" 8 "Sep" 9 "Oct" 10 "Nov" 11 "Dec" 12 }}
         {{ $items := slice }}
         {{ range .Site.Data.releases }}
+          {{ if not .archived }}
           {{ range .list }}
           {{ $rels := or .source .distribution }}
           {{ if and .name $rels }}
@@ -48,6 +58,7 @@
               {{ end }}
             {{ end }}
             {{ $items = $items | append (dict "name" .name "ver" $rel.version "date" $rel.date "id" (replace .name " " "") "key" $key) }}
+          {{ end }}
           {{ end }}
           {{ end }}
         {{ end }}

--- a/layouts/partials/downloads-cards.html
+++ b/layouts/partials/downloads-cards.html
@@ -1,0 +1,127 @@
+{{- /* One category's release cards. Context is a data/releases.yml category. */ -}}
+<div class="dl-grid">
+  {{ range .list }}
+  {{ $id := replace .name " " "" }}
+  {{ $name := .name }}
+  <article class="dl-card" id="{{ $id }}">
+    <header class="dl-card-head">
+      {{ if .icon }}<img class="dl-icon" width="34" height="34" src="/images/project/{{ .icon }}.svg" alt="">{{ end }}
+      <h5 class="dl-card-title">{{ .name }}</h5>
+      <a class="card-anchor" href="#{{ $id }}" data-anchor="{{ $id }}" title="Copy link to {{ $name }}" aria-label="Copy link to {{ $name }}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+      </a>
+    </header>
+    {{ with .description }}<p class="dl-card-desc">{{ . }}</p>{{ end }}
+
+    {{ if .sourceText }}
+    <div class="dl-note">{{ .sourceText }}</div>
+    {{ else }}
+
+    {{- /* ---- Source: latest visible; older in a top-right dropdown ---- */ -}}
+    {{ if .source }}
+    {{ $latest := index .source 0 }}
+    {{ $more := after 1 .source }}
+    <div class="dl-rel">
+      <div class="dl-rel-head">
+        <span class="dl-rel-label">Source</span>
+        {{ if $more }}
+        <details class="dl-more">
+          <summary>+{{ len $more }} more</summary>
+          <ul class="dl-dd-list">
+            {{ range $more }}
+            {{ $v := .version }}
+            <li class="dl-row">
+              <span class="dl-row-ver">{{ .version }}</span>
+              <span class="dl-row-date">{{ .date }}</span>
+              <span class="dl-links">
+                {{ range .downloadLink }}
+                {{ if eq .name "|" }}
+                {{ else if or (eq .name "asc") (eq .name "sha512") }}
+                <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
+                {{ else }}
+                <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
+                {{ end }}
+                {{ end }}
+              </span>
+            </li>
+            {{ end }}
+          </ul>
+        </details>
+        {{ end }}
+      </div>
+      {{ with $latest }}
+      {{ $v := .version }}
+      <div class="dl-row is-latest">
+        <span class="dl-row-ver">{{ .version }} <span class="dl-latesttag">latest</span></span>
+        <span class="dl-row-date">{{ .date }}</span>
+        <span class="dl-links">
+          {{ range .downloadLink }}
+          {{ if eq .name "|" }}
+          {{ else if or (eq .name "asc") (eq .name "sha512") }}
+          <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
+          {{ else }}
+          <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
+          {{ end }}
+          {{ end }}
+        </span>
+      </div>
+      {{ end }}
+    </div>
+    {{ end }}
+
+    {{- /* ---- Distribution: latest visible; older in a top-right dropdown ---- */ -}}
+    {{ with .distribution }}
+    {{ $latest := index . 0 }}
+    {{ $dmore := after 1 . }}
+    <div class="dl-rel">
+      <div class="dl-rel-head">
+        <span class="dl-rel-label">Distribution</span>
+        {{ if $dmore }}
+        <details class="dl-more">
+          <summary>+{{ len $dmore }} more</summary>
+          <ul class="dl-dd-list">
+            {{ range $dmore }}
+            {{ $v := .version }}
+            <li class="dl-row">
+              <span class="dl-row-ver">{{ .version }}</span>
+              <span class="dl-row-date">{{ .date }}</span>
+              <span class="dl-links">
+                {{ range .downloadLink }}
+                {{ if eq .name "|" }}
+                {{ else if or (eq .name "asc") (eq .name "sha512") }}
+                <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
+                {{ else }}
+                <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
+                {{ end }}
+                {{ end }}
+              </span>
+            </li>
+            {{ end }}
+          </ul>
+        </details>
+        {{ end }}
+      </div>
+      {{ with $latest }}
+      {{ $v := .version }}
+      <div class="dl-row is-latest">
+        <span class="dl-row-ver">{{ .version }} <span class="dl-latesttag">latest</span></span>
+        <span class="dl-row-date">{{ .date }}</span>
+        <span class="dl-links">
+          {{ range .downloadLink }}
+          {{ if eq .name "|" }}
+          {{ else if or (eq .name "asc") (eq .name "sha512") }}
+          <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
+          {{ else }}
+          <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
+          {{ end }}
+          {{ end }}
+        </span>
+      </div>
+      {{ end }}
+    </div>
+    {{ end }}
+
+    {{ end }}{{/* end sourceText else */}}
+  </article>
+  {{ end }}
+</div>

--- a/layouts/shortcodes/downloads-block.html
+++ b/layouts/shortcodes/downloads-block.html
@@ -1,135 +1,14 @@
 {{- /* Downloads — light card grid. Same data shape as data/releases.yml.
-       Latest release prominent; older versions collapsed in a <details>. */ -}}
+       Latest release prominent; older versions collapsed in a <details>.
+       Categories flagged `archived: true` render last, after the Docker
+       images, folded shut — most readers are looking for current releases. */ -}}
 {{ range .Site.Data.releases }}
+{{ if not .archived }}
 {{ $cat := or .buttonText (replace .type " " "") }}
 <h2 class="dl-cat" id="{{ $cat }}">{{ .type }}</h2>
 {{ with .description }}<div class="dl-cat-note">{{ . | markdownify }}</div>{{ end }}
-<div class="dl-grid">
-  {{ range .list }}
-  {{ $id := replace .name " " "" }}
-  {{ $name := .name }}
-  <article class="dl-card" id="{{ $id }}">
-    <header class="dl-card-head">
-      {{ if .icon }}<img class="dl-icon" width="34" height="34" src="/images/project/{{ .icon }}.svg" alt="">{{ end }}
-      <h5 class="dl-card-title">{{ .name }}</h5>
-      <a class="card-anchor" href="#{{ $id }}" data-anchor="{{ $id }}" title="Copy link to {{ $name }}" aria-label="Copy link to {{ $name }}">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-      </a>
-    </header>
-    {{ with .description }}<p class="dl-card-desc">{{ . }}</p>{{ end }}
-
-    {{ if .sourceText }}
-    <div class="dl-note">{{ .sourceText }}</div>
-    {{ else }}
-
-    {{- /* ---- Source: latest visible; older in a top-right dropdown ---- */ -}}
-    {{ if .source }}
-    {{ $latest := index .source 0 }}
-    {{ $more := after 1 .source }}
-    <div class="dl-rel">
-      <div class="dl-rel-head">
-        <span class="dl-rel-label">Source</span>
-        {{ if $more }}
-        <details class="dl-more">
-          <summary>+{{ len $more }} more</summary>
-          <ul class="dl-dd-list">
-            {{ range $more }}
-            {{ $v := .version }}
-            <li class="dl-row">
-              <span class="dl-row-ver">{{ .version }}</span>
-              <span class="dl-row-date">{{ .date }}</span>
-              <span class="dl-links">
-                {{ range .downloadLink }}
-                {{ if eq .name "|" }}
-                {{ else if or (eq .name "asc") (eq .name "sha512") }}
-                <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
-                {{ else }}
-                <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
-                {{ end }}
-                {{ end }}
-              </span>
-            </li>
-            {{ end }}
-          </ul>
-        </details>
-        {{ end }}
-      </div>
-      {{ with $latest }}
-      {{ $v := .version }}
-      <div class="dl-row is-latest">
-        <span class="dl-row-ver">{{ .version }} <span class="dl-latesttag">latest</span></span>
-        <span class="dl-row-date">{{ .date }}</span>
-        <span class="dl-links">
-          {{ range .downloadLink }}
-          {{ if eq .name "|" }}
-          {{ else if or (eq .name "asc") (eq .name "sha512") }}
-          <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
-          {{ else }}
-          <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Source]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
-          {{ end }}
-          {{ end }}
-        </span>
-      </div>
-      {{ end }}
-    </div>
-    {{ end }}
-
-    {{- /* ---- Distribution: latest visible; older in a top-right dropdown ---- */ -}}
-    {{ with .distribution }}
-    {{ $latest := index . 0 }}
-    {{ $dmore := after 1 . }}
-    <div class="dl-rel">
-      <div class="dl-rel-head">
-        <span class="dl-rel-label">Distribution</span>
-        {{ if $dmore }}
-        <details class="dl-more">
-          <summary>+{{ len $dmore }} more</summary>
-          <ul class="dl-dd-list">
-            {{ range $dmore }}
-            {{ $v := .version }}
-            <li class="dl-row">
-              <span class="dl-row-ver">{{ .version }}</span>
-              <span class="dl-row-date">{{ .date }}</span>
-              <span class="dl-links">
-                {{ range .downloadLink }}
-                {{ if eq .name "|" }}
-                {{ else if or (eq .name "asc") (eq .name "sha512") }}
-                <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
-                {{ else }}
-                <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
-                {{ end }}
-                {{ end }}
-              </span>
-            </li>
-            {{ end }}
-          </ul>
-        </details>
-        {{ end }}
-      </div>
-      {{ with $latest }}
-      {{ $v := .version }}
-      <div class="dl-row is-latest">
-        <span class="dl-row-ver">{{ .version }} <span class="dl-latesttag">latest</span></span>
-        <span class="dl-row-date">{{ .date }}</span>
-        <span class="dl-links">
-          {{ range .downloadLink }}
-          {{ if eq .name "|" }}
-          {{ else if or (eq .name "asc") (eq .name "sha512") }}
-          <a class="dl-link dl-link--sig" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }}</a>
-          {{ else }}
-          <a class="dl-link dl-link--mini" href="{{ .link }}" target="_blank" rel="noopener" data-label="[{{ $name }}]-[Distribution]-[{{ $v }}]-[{{ .name }}]">{{ .name }} ↓</a>
-          {{ end }}
-          {{ end }}
-        </span>
-      </div>
-      {{ end }}
-    </div>
-    {{ end }}
-
-    {{ end }}{{/* end sourceText else */}}
-  </article>
-  {{ end }}
-</div>
+{{ partial "downloads-cards.html" . }}
+{{ end }}
 {{ end }}
 
 {{- /* ---- Docker images ---- */ -}}
@@ -147,3 +26,21 @@
   </article>
   {{ end }}
 </div>
+
+{{- /* ---- Archived categories, folded, after everything else ---- */ -}}
+{{ range .Site.Data.releases }}
+{{ if .archived }}
+{{ $cat := or .buttonText (replace .type " " "") }}
+{{ $n := len .list }}
+<details class="dl-archived" id="{{ $cat }}">
+  <summary>
+    <span class="dl-archived-title">{{ .type }}</span>
+    <span class="dl-archived-count">{{ $n }} component{{ if ne $n 1 }}s{{ end }}</span>
+  </summary>
+  <div class="dl-archived-body">
+    {{ with .description }}<div class="dl-cat-note">{{ . | markdownify }}</div>{{ end }}
+    {{ partial "downloads-cards.html" . }}
+  </div>
+</details>
+{{ end }}
+{{ end }}

--- a/layouts/shortcodes/downloads-block.html
+++ b/layouts/shortcodes/downloads-block.html
@@ -3,6 +3,7 @@
 {{ range .Site.Data.releases }}
 {{ $cat := or .buttonText (replace .type " " "") }}
 <h2 class="dl-cat" id="{{ $cat }}">{{ .type }}</h2>
+{{ with .description }}<div class="dl-cat-note">{{ . | markdownify }}</div>{{ end }}
 <div class="dl-grid">
   {{ range .list }}
   {{ $id := replace .name " " "" }}


### PR DESCRIPTION
Follow-up to #899, covering two things on the downloads page.

## 1. Restore the archive links the redesign dropped

The *Archived Releases* section did once have content. #431 (Apr 2022) added `- type: Archive` to `releases.yml` **purely so the section got a nav chip** — it deliberately had no `list:`, and the real content was a hardcoded block in `downloads-block.html`:

> Older releases are not recommended for new users, because they are not maintained, but you still can find them(source codes and binaries) if you have specific reasons.
>
> Find all SkyWalking releases in the [Archive repository](https://archive.apache.org/dist/skywalking/).
>
> [Archive incubating repository](https://archive.apache.org/dist/incubator/skywalking/) hosts older releases when SkyWalking was an incubator project.

The redesign (#844, May 2026) rewrote that shortcode and dropped the block, leaving the by-then-renamed `Archived Releases` entry orphaned. With no `list:` and no block, the chip and `<h2>` have been rendering above an empty grid ever since.

Restored as the category `description` so it is data-driven rather than hardcoded. Every other category has a null description, so exactly one note renders.

## 2. Fold archived releases, and move them below the Docker images

Most people on this page want something current, so an archived category no longer sits mid-page between Tools and Docker. It now renders **last, after the Docker images**, as a `<details>` shut by default showing just its title and a component count.

Categories opt in with `archived: true` in `releases.yml` — a property of the data, not a special case for one hardcoded section. The chip strip and the "Latest releases" aside follow the same flag: archived chips move after the Docker chip and are muted, and archived components no longer compete for a slot in the aside.

The card grid moved to `layouts/partials/downloads-cards.html` so the live and folded paths render identical markup.

**Anchors keep working.** A `<details>` containing the target of `location.hash` is opened on load and on `hashchange`, so `/downloads/#BanyanDBJavaClient` and the *Archived Releases* chip both land on an expanded section.

## Verification

Local Hugo build, no errors.

Order, chips and body both:

```
Foundations, Agents, Operation, Database, Tools, DockerImages, ArchivedReleases
```

| check | result |
| --- | --- |
| `<details>` open by default | no |
| summary | "Archived Releases" + "1 component" (singular) |
| cards per section | Foundations 4, Agents 13, Operation 4, Database 3, Tools 2, Docker 18, Archived 1 — unchanged by the partial extraction |
| `dl-cat-note` on page | 1 (Archived Releases only) |
| restored links | both return 200 |
| "Latest releases" aside | Java, Python, Go, NodeJS, Horizon UI — no archived entries |
| compiled CSS | `.dl-archived`, `[open]` chevron rotation, `.dl-chip--muted` all present |

## Context: why the section had no components until now

No previously-archived repo ever had its own release artifacts to move here:

- **Rocketbot UI → Booster UI** always carried `sourceText: Included in the main repo release` — no standalone downloads. When Booster UI was archived (c8b39b8, May 2026) its entry was simply replaced by Horizon UI.
- **Docker Files, Legacy UI, OAL Generator** never had `releases.yml` entries at all.

The BanyanDB Java Client is the first retired component that shipped its own signed release, which is why #899 produced the section's first card.