### PR TITLE
Blog: paginate the post indexes, and give the Chinese posts working label filtering

### DIFF
--- a/content/zh/tags/_index.md
+++ b/content/zh/tags/_index.md
@@ -1,0 +1,5 @@
+---
+title: "按主题浏览"
+description: "按主题浏览 Apache SkyWalking 中文博客文章。"
+layout: tagindex
+---

--- a/content/zh/tags/agents/_index.md
+++ b/content/zh/tags/agents/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Agents"
+description: "标签 Agents 下的 Apache SkyWalking 中文博客文章。"
+topic: "Agents"
+layout: tagterm
+---

--- a/content/zh/tags/ai/_index.md
+++ b/content/zh/tags/ai/_index.md
@@ -1,0 +1,6 @@
+---
+title: "AI"
+description: "标签 AI 下的 Apache SkyWalking 中文博客文章。"
+topic: "AI"
+layout: tagterm
+---

--- a/content/zh/tags/cloud-native/_index.md
+++ b/content/zh/tags/cloud-native/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Cloud Native"
+description: "标签 Cloud Native 下的 Apache SkyWalking 中文博客文章。"
+topic: "Cloud Native"
+layout: tagterm
+---

--- a/content/zh/tags/community/_index.md
+++ b/content/zh/tags/community/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Community"
+description: "标签 Community 下的 Apache SkyWalking 中文博客文章。"
+topic: "Community"
+layout: tagterm
+---

--- a/content/zh/tags/engineering/_index.md
+++ b/content/zh/tags/engineering/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Engineering"
+description: "标签 Engineering 下的 Apache SkyWalking 中文博客文章。"
+topic: "Engineering"
+layout: tagterm
+---

--- a/content/zh/tags/logging/_index.md
+++ b/content/zh/tags/logging/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Logging"
+description: "标签 Logging 下的 Apache SkyWalking 中文博客文章。"
+topic: "Logging"
+layout: tagterm
+---

--- a/content/zh/tags/metrics/_index.md
+++ b/content/zh/tags/metrics/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Metrics"
+description: "标签 Metrics 下的 Apache SkyWalking 中文博客文章。"
+topic: "Metrics"
+layout: tagterm
+---

--- a/content/zh/tags/profiling/_index.md
+++ b/content/zh/tags/profiling/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Profiling"
+description: "标签 Profiling 下的 Apache SkyWalking 中文博客文章。"
+topic: "Profiling"
+layout: tagterm
+---

--- a/content/zh/tags/release/_index.md
+++ b/content/zh/tags/release/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Release"
+description: "标签 Release 下的 Apache SkyWalking 中文博客文章。"
+topic: "Release"
+layout: tagterm
+---

--- a/content/zh/tags/storage/_index.md
+++ b/content/zh/tags/storage/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Storage"
+description: "标签 Storage 下的 Apache SkyWalking 中文博客文章。"
+topic: "Storage"
+layout: tagterm
+---

--- a/content/zh/tags/tracing/_index.md
+++ b/content/zh/tags/tracing/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Tracing"
+description: "标签 Tracing 下的 Apache SkyWalking 中文博客文章。"
+topic: "Tracing"
+layout: tagterm
+---

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -5,7 +5,10 @@
 {{ $.Scratch.Set "blog-pages" .Pages }}
 {{- end -}}
 {{ $pages := ($.Scratch.Get "blog-pages") }}
-{{ $groups := $pages.GroupByDate (i18n "year") }}
+{{- /* Paginated: a single page carrying every post was unusable. Year groups
+       come from the current pager page, so a year heading can repeat across
+       pages; the topic-filter counts below stay on the full set. */ -}}
+{{ $pag := .Paginate ($pages.GroupByDate (i18n "year")) 24 }}
 
 {{- /* Topics (name + intro + color) are defined in data/blog_topics.yml. */ -}}
 {{ $topics := .Site.Data.blog_topics.topics }}
@@ -54,7 +57,7 @@
   </div>
 
   <div class="blog-content">
-    {{ range $groups }}
+    {{ range $pag.PageGroups }}
     <h2 class="blog-year">{{ T "post_posts_in" }} {{ .Key }}</h2>
     <div class="blog-grid">
       {{ range .Pages }}
@@ -74,6 +77,10 @@
       {{ end }}
     </div>
     {{ end }}
+  </div>
+
+  <div class="blog-pagination">
+    {{ template "_internal/pagination.html" . }}
   </div>
 </div>
 {{ end }}

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -1,0 +1,33 @@
+{{ define "main" }}
+{{- /* /tags/ — the topic directory, the English mirror of layouts/zh/tagindex.html.
+       This page rendered empty before: there was no layout for the taxonomy list,
+       only for its terms. Counts are English posts only, matching the term pages. */ -}}
+{{ $topics := .Site.Data.blog_topics.topics }}
+{{ $blog := where .Site.RegularPages "Section" "blog" }}
+
+<section class="blog-hero">
+  <div class="container">
+    <a class="bf-back" href="{{ "/blog/" | relLangURL }}">← All posts</a>
+    <h1>Browse topics</h1>
+    <p>{{ len $blog }} posts, grouped by topic.</p>
+  </div>
+</section>
+
+<div class="container blog-wrap">
+  <div class="topic-filter-grid">
+    {{ range $topics }}
+    {{ $t := .name }}
+    {{ $tagged := where $blog ".Params.tags" "intersect" (slice $t) }}
+    {{ if gt (len $tagged) 0 }}
+    <a class="topic-filter-card" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
+      <span class="topic-filter-card-top">
+        <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
+        <span class="album-count">{{ len $tagged }}</span>
+      </span>
+      <span class="topic-filter-card-intro">{{ .intro }}</span>
+    </a>
+    {{ end }}
+    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/layouts/zh/content.html
+++ b/layouts/zh/content.html
@@ -9,7 +9,7 @@
   {{ with .Params.tags }}
   <div class="post-tags-list post-tags-list--inline">
     {{ range . }}
-    <a class="blog-label" data-label="{{ . }}" href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>
+    <a class="blog-label" data-label="{{ . }}" href="{{ printf "/zh/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>
     {{ end }}
   </div>
   {{ end }}

--- a/layouts/zh/list.html
+++ b/layouts/zh/list.html
@@ -5,7 +5,10 @@
 {{ $.Scratch.Set "blog-pages" .Pages }}
 {{- end -}}
 {{ $pages := ($.Scratch.Get "blog-pages") }}
-{{ $groups := $pages.GroupByDate (i18n "year") }}
+{{- /* Paginated: a single page carrying every post was unusable. Year groups
+       come from the current pager page, so a year heading can repeat across
+       pages; the topic-filter counts below stay on the full set. */ -}}
+{{ $pag := .Paginate ($pages.GroupByDate (i18n "year")) 24 }}
 
 {{ $topics := .Site.Data.blog_topics.topics }}
 
@@ -62,7 +65,7 @@
   </div>
 
   <div class="blog-content">
-    {{ range $groups }}
+    {{ range $pag.PageGroups }}
     <h2 class="blog-year">{{ .Key }} 年</h2>
     <div class="blog-grid">
       {{ range .Pages }}
@@ -82,6 +85,10 @@
       {{ end }}
     </div>
     {{ end }}
+  </div>
+
+  <div class="blog-pagination">
+    {{ template "_internal/pagination.html" . }}
   </div>
 </div>
 {{ end }}

--- a/layouts/zh/list.html
+++ b/layouts/zh/list.html
@@ -50,7 +50,7 @@
           {{ $t := .name }}
           {{ $tagged := where $pages ".Params.tags" "intersect" (slice $t) }}
           {{ if gt (len $tagged) 0 }}
-          <a class="topic-filter-card" href="{{ printf "/tags/%s/" ($t | urlize) | relLangURL }}">
+          <a class="topic-filter-card" href="{{ printf "/zh/tags/%s/" ($t | urlize) | relLangURL }}">
             <span class="topic-filter-card-top">
               <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
               <span class="album-count">{{ len $tagged }}</span>
@@ -72,7 +72,7 @@
       <article class="blog-card">
         {{ with .Params.tags }}
         <div class="blog-labels">
-          {{ range . }}<a class="blog-label" data-label="{{ . }}" href="{{ printf "/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>{{ end }}
+          {{ range . }}<a class="blog-label" data-label="{{ . }}" href="{{ printf "/zh/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>{{ end }}
         </div>
         {{ end }}
         <h3 class="blog-card-title"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h3>

--- a/layouts/zh/tagindex.html
+++ b/layouts/zh/tagindex.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+{{- /* /zh/tags/ — the topic directory the CN blog's "按主题浏览" menu points into.
+       Counts come from the Chinese posts only, so they match the term pages. */ -}}
+{{ $topics := .Site.Data.blog_topics.topics }}
+{{ $zh := where .Site.RegularPages "Section" "zh" }}
+
+<section class="blog-hero">
+  <div class="container">
+    <a class="bf-back" href="{{ "/zh/" | relLangURL }}">← 全部文章</a>
+    <h1>按主题浏览</h1>
+    <p>共 {{ len $zh }} 篇中文文章，按主题分类。</p>
+  </div>
+</section>
+
+<div class="container blog-wrap">
+  <div class="topic-filter-grid">
+    {{ range $topics }}
+    {{ $t := .name }}
+    {{ $tagged := where $zh ".Params.tags" "intersect" (slice $t) }}
+    {{ if gt (len $tagged) 0 }}
+    <a class="topic-filter-card" href="{{ printf "/zh/tags/%s/" ($t | urlize) | relLangURL }}">
+      <span class="topic-filter-card-top">
+        <span class="blog-label" data-label="{{ $t }}">{{ $t }}</span>
+        <span class="album-count">{{ len $tagged }}</span>
+      </span>
+      <span class="topic-filter-card-intro">{{ .intro_zh }}</span>
+    </a>
+    {{ end }}
+    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/layouts/zh/tagterm.html
+++ b/layouts/zh/tagterm.html
@@ -1,0 +1,49 @@
+{{ define "main" }}
+{{- /* Chinese tag term page — the CN mirror of layouts/tags/term.html.
+
+       /zh/ posts share the global `tags` taxonomy with /blog/, so they cannot
+       have their own term pages at /tags/<term>/: one URL can only render one
+       list, and that one is English. These are therefore real content stubs
+       under content/zh/tags/<slug>/, carrying the canonical topic name in the
+       `topic` front-matter field.
+
+       Filter first, then page — same as the English side. */ -}}
+{{ $topic := .Params.topic }}
+{{ $zhPages := where (where .Site.RegularPages "Section" "zh") ".Params.tags" "intersect" (slice $topic) }}
+{{ $pag := .Paginate $zhPages 12 }}
+
+<section class="blog-hero">
+  <div class="container">
+    <a class="bf-back" href="{{ "/zh/" | relLangURL }}">← 全部文章</a>
+    <div class="tag-hero-top">
+      <span class="blog-label tag-hero-chip" data-label="{{ $topic }}">{{ $topic }}</span>
+      <span class="tag-hero-count">{{ len $zhPages }} 篇文章</span>
+    </div>
+    <h1>「{{ $topic }}」相关文章</h1>
+  </div>
+</section>
+
+<div class="container blog-wrap">
+  <div class="blog-grid">
+    {{ range $pag.Pages }}
+    <article class="blog-card">
+      {{ with .Params.tags }}
+      <div class="blog-labels">
+        {{ range . }}<a class="blog-label" data-label="{{ . }}" href="{{ printf "/zh/tags/%s/" (. | urlize) | relLangURL }}">{{ . }}</a>{{ end }}
+      </div>
+      {{ end }}
+      <h3 class="blog-card-title"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h3>
+      <p class="blog-card-preview">{{ with .Description }}{{ . }}{{ else }}{{ .Plain | safeHTML | truncate 160 }}{{ end }}</p>
+      <div class="blog-card-foot">
+        <span class="blog-date">{{ .Date.Format "2006-01-02" }}</span>
+        {{ with .Params.author }}<span class="blog-author">{{ . | markdownify }}</span>{{ end }}
+      </div>
+    </article>
+    {{ end }}
+  </div>
+
+  <div class="blog-pagination">
+    {{ template "_internal/pagination.html" . }}
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
`/blog/` was rendering all 101 posts and `/zh/` all 112, each in a single document. Both now page at **24 posts, five pages each**.

## Approach

Reuses what the site already has rather than inventing anything:

- the **paginated-year-groups** shape from `layouts/events/list.html` — `.Paginate` over `GroupByDate`, then `range $pag.PageGroups`
- the **`.blog-pagination` markup and styles** the tag pages (`layouts/tags/term.html`) already ship, so no new CSS

Year headings come from the current pager page, so a year can appear at the end of one page and the start of the next — same behaviour as the events timeline. The topic-filter counts still read the full post set, not the current page.

## Page size

24, chosen against the actual distribution: posts per year run 2–26, so 24 keeps most year groups whole (only 2026, at 26 posts, spills) and suits the 3-up grid at 8 rows. It's one number per file if you'd rather have 12 like the tag pages.

## Verification

Clean `hugo` build (`rm -rf public resources` first — stale output otherwise lies).

| | `/blog/` | `/zh/` |
| --- | --- | --- |
| pager pages | 5 | 5 |
| cards across all pagers | 101 | 112 |
| cards before this change | 101 | 112 |

Counted the pre-change build by stashing the diff, so the totals are a measured before/after, not an assumption — **no post became unreachable**.

Also checked:

- **Feeds unaffected** — `layouts/_default/list.rss.xml` does not paginate; `/blog/feed.xml` and `/zh/feed.xml` still carry their 20 items.
- **Sitemap unaffected** — Hugo excludes pager pages; `grep -c 'page/[0-9]' public/sitemap.xml` is 0.
- **`/blog/page/1/`** is Hugo's standard meta-refresh alias back to `/blog/`.

## Note on canonicals

Pager pages canonicalise to `/blog/` (and `/zh/`), because `seo/meta.html` uses `.Permalink`, which is the section URL on every pager. That is coherent here — pager pages are absent from the sitemap, and every post carries its own canonical and its own sitemap entry — but it is not the self-referencing canonical Google prefers for paginated series.

**Making them self-referencing is not a small change, and the failure mode is silent.** I tried the obvious fix (`{{ with .Paginator }}` in `seo/meta.html`) and the build still exits 0 while producing a **completely empty blog**: the head partial runs before `main`, so `.Paginator` initialises a default paginator over `.Pages` at pagerSize 10, `list.html`'s `.Paginate(groups, 24)` then returns *that* paginator instead of a grouped one, `$pag.PageGroups` is empty, and every page renders zero cards across 11 pagers. Left alone deliberately; worth its own change if you want it.

## Unrelated content bugs spotted

Two `content/zh` directories produce no page, which is why `/zh/` shows 112 posts and not 114. Both predate this change and I have not touched them:

- `content/zh/2022-01-24-scaling-with-apache-skywalking/` — 10 images, no `index.md`
- `content/zh/2026-01-01-skywalking-2025-year-in-review/` — empty directory