### PR TITLE
Align project card titles with their icons on /downloads and /docs

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -486,9 +486,13 @@
     border-color: $brand;
     box-shadow: 0 0 0 3px rgba(55, 136, 208, .25), 0 16px 40px -22px rgba(17, 24, 39, .3);
   }
-  .docs-card-head { display: flex; align-items: center; gap: 9px; margin-bottom: 8px; min-height: 30px; }
+  // 37px = the 30px icon, or a wrapped 2-line title (2 x 14.5px x 1.25), whichever is taller,
+  // so the description below starts at the same y on every card in a row
+  .docs-card-head { display: flex; align-items: center; gap: 9px; margin-bottom: 8px; min-height: 37px; }
   .docs-icon { flex: 0 0 30px; width: 30px; height: 30px; object-fit: contain; }
-  .docs-card-title { margin: 0; font-size: 14.5px; font-weight: 700; color: $ink; line-height: 1.25; flex: 1; }
+  // padding-top:0 kills the global `h1..h6 { padding-top: 1.1rem }` from the theme,
+  // which otherwise pads the flex item and drops the name ~9px below the icon.
+  .docs-card-title { margin: 0; padding: 0; font-size: 14.5px; font-weight: 700; color: $ink; line-height: 1.25; flex: 1; }
   .docs-stars {
     display: inline-flex; align-items: center; gap: 4px;
     padding: 2px 8px; border-radius: 999px;

--- a/assets/scss/_custom_home.scss
+++ b/assets/scss/_custom_home.scss
@@ -1549,7 +1549,9 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
     flex: 0 0 26px; width: 26px; height: 26px;
     object-fit: contain; display: block;
   }
-  .dl-card-title { margin: 0; font-size: 14px; font-weight: 700; color: $ink; line-height: 1.25; }
+  // padding-top:0 kills the global `h1..h6 { padding-top: 1.1rem }` from the theme,
+  // which otherwise pads the flex item and drops the name ~9px below the icon.
+  .dl-card-title { margin: 0; padding: 0; font-size: 14px; font-weight: 700; color: $ink; line-height: 1.25; }
   .dl-card-desc {
     margin: 0 0 10px; font-size: 12px; color: $body; line-height: 1.5;
     min-height: 36px;   // reserve 2 lines so blocks below stay aligned
@@ -1637,7 +1639,7 @@ $brand-grad: linear-gradient(180deg, #479EEB 0%, #3788D0 100%);
   }
 
   .dl-card--docker {
-    h5 { margin: 0 0 6px; font-size: 14px; font-weight: 700; color: $ink; }
+    h5 { margin: 0 0 6px; padding: 0; font-size: 14px; font-weight: 700; color: $ink; }
     p  { margin: 0 0 14px; font-size: 12.5px; color: $body; line-height: 1.5; flex: 1; }
     .dl-link--main { align-self: flex-start; }
   }

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -481,7 +481,7 @@
             - name: sha512
               link: https://downloads.apache.org/skywalking/python/1.3.0/skywalking-python-src-1.3.0.tgz.sha512
         - version: v1.2.0
-          date: "2025-05-11"
+          date: May 11th, 2025
           downloadLink:
             - name: src
               link: https://archive.apache.org/dist/skywalking/python/1.2.0/skywalking-python-src-1.2.0.tgz
@@ -496,7 +496,7 @@
             - name: Install via pip
               link: https://pypi.org/project/apache-skywalking/1.3.0/
         - version: v1.2.0
-          date: 2025-05-11
+          date: May 11th, 2025
           downloadLink:
             - name: Install via pip
               link: https://pypi.org/project/apache-skywalking/1.2.0/
@@ -528,7 +528,7 @@
       description: The NodeJS Agent for Apache SkyWalking, which provides the native tracing abilities for NodeJS projects.
       source:
         - version: v0.9.0
-          date: "2026-06-26"
+          date: Jun. 26th, 2026
           downloadLink:
             - name: src
               link: https://www.apache.org/dyn/closer.cgi/skywalking/node-js/0.9.0/skywalking-nodejs-src-0.9.0.tgz
@@ -538,7 +538,7 @@
               link: https://downloads.apache.org/skywalking/node-js/0.9.0/skywalking-nodejs-src-0.9.0.tgz.sha512
       distribution:
         - version: 0.9.0
-          date: "2026-06-26"
+          date: Jun. 26th, 2026
           downloadLink:
             - name: Install via npm
               link: https://npmjs.com/package/skywalking-backend-js


### PR DESCRIPTION
## What

Project names sat about 9px below their icons on every card of `/downloads` and `/docs`.

## Why

The theme sets a global heading rule:

```scss
// themes/docsy/assets/scss/_styles_project.scss
h1, h2, h3, h4, h5, h6 { padding-top: 1.1rem; }
```

Both card titles are `<h5>` and reset only `margin`, never `padding`. That 17.6px lived *inside* the flex item, so `align-items: center` centered the padded box rather than the text — pushing the visible name down on every card, on both pages.

## Changes

- `padding: 0` on `.dl-card-title` (downloads cards) and `.docs-card-title` (documentation cards).
- `padding: 0` on the Docker card's `h5` — same page, same inherited padding, so its title would otherwise sit lower than its neighbours'.
- `.docs-card-head` min-height 30px → 37px. 30px only covered the icon; with the padding gone, a wrapped 2-line title is 36.25px and would have pushed that card's description below its neighbours'. 37px covers both. `.dl-card-head`'s existing 44px already covers the new, shorter content, so it is unchanged.

Also normalizes two release dates in `data/releases.yml` that were still in ISO form — NodeJS Agent 0.9.0 (`2026-06-26`) and Python Agent 1.2.0 (`2025-05-11`) — to the site's `Mon. DDth, YYYY` format. They were the only two left.

## Verification

Built the site with Hugo and screenshotted both pages headless at 1440px. Icon and name are now centered on each other, and the blocks below line up across each row — including the wrapped "SkyWalking GraalVM Distro" card, whose SOURCE/DISTRIBUTION rows stay level with its neighbours'.