### PR TITLE
Quickstart: SkyWalking 11.0.0, Horizon UI 1.0.0, BanyanDB 0.11.0

### DIFF
--- a/content/horizon.yaml
+++ b/content/horizon.yaml
@@ -40,12 +40,17 @@ oap:
   adminUrl: http://oap:17128
   zipkinUrl: http://oap:9412/zipkin
 
-# Demo login: admin / admin. Change before exposing this beyond localhost.
-# rbac defaults to enabled with the admin role granting `*`.
+# Quickstart login: skywalking / skywalking. Change before exposing this beyond
+# localhost. rbac defaults to enabled with the admin role granting `*`.
+#
+# The hash is Argon2id with the node-argon2 defaults (m=65536, t=3, p=4),
+# generated with the argon2 module inside the Horizon image itself. To rotate it:
+#   docker run --rm --entrypoint node apache/skywalking-ui:horizon-<version> \
+#     -e 'require("/app/node_modules/argon2").hash("<password>").then(console.log)'
 auth:
   backend: local
   local:
     users:
-      - username: admin
-        passwordHash: "$argon2id$v=19$m=65536,t=3,p=4$joV9AVlyLS3pqq4mLrYokQ$pJLkTKrz9/LzEH6YaFljdz9k8dyBiryjwSB26Diiz9U"
+      - username: skywalking
+        passwordHash: "$argon2id$v=19$m=65536,t=3,p=4$ulwTy/981LUpNFfSAjmKAg$lpp0WRYPoiGDoWA3Lg2e+CvCffIHE0TDEUsQMnjcwsU"
         roles: [admin]

--- a/content/horizon.yaml
+++ b/content/horizon.yaml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Horizon UI config for the quickstart, served from
+# https://skywalking.apache.org/horizon.yaml and fetched by
+# content/quickstart-docker.{sh,ps1} beside the compose manifest.
+#
+# The Horizon image reads its backend wiring and login users ONLY from this
+# file (mounted at the image's HORIZON_CONFIG path) — there are no env vars
+# for the OAP URLs. The service names below must match the ones in the
+# compose manifest the scripts download.
+#
+# Kept here rather than pulled from a branch tip so the quickstart stays
+# reproducible: this copy is reviewed alongside the image versions the
+# scripts pin. The upstream reference config lives at
+# https://github.com/apache/skywalking-horizon-ui (docs/setup).
+
+server:
+  # Bind all interfaces. The default example config ships host: 127.0.0.1,
+  # which binds container-loopback only and 503s from the host side.
+  host: 0.0.0.0
+  port: 8081
+
+oap:
+  # Point at the `oap` service on the compose network, not 127.0.0.1.
+  queryUrl: http://oap:12800
+  adminUrl: http://oap:17128
+  zipkinUrl: http://oap:9412/zipkin
+
+# Demo login: admin / admin. Change before exposing this beyond localhost.
+# rbac defaults to enabled with the admin role granting `*`.
+auth:
+  backend: local
+  local:
+    users:
+      - username: admin
+        passwordHash: "$argon2id$v=19$m=65536,t=3,p=4$joV9AVlyLS3pqq4mLrYokQ$pJLkTKrz9/LzEH6YaFljdz9k8dyBiryjwSB26Diiz9U"
+        roles: [admin]

--- a/content/quickstart-docker.ps1
+++ b/content/quickstart-docker.ps1
@@ -15,13 +15,16 @@
 # limitations under the License.
 
 # Default values for SkyWalking versions
-$SW_VERSION = "10.2.0"
-$SW_BANYANDB_VERSION = "0.8.0"
+$SW_VERSION = "11.0.0"
+$SW_HORIZON_UI_VERSION = "1.0.0"
+$SW_BANYANDB_VERSION = "0.11.0"
 
 $COMPOSE_FILE_PATH = ".\docker-compose.yml"
+$HORIZON_CONFIG_PATH = ".\horizon.yaml"
 $env:BANYANDB_IMAGE = "apache/skywalking-banyandb:$SW_BANYANDB_VERSION"
 $env:OAP_IMAGE = "apache/skywalking-oap-server:$SW_VERSION"
-$env:UI_IMAGE = "apache/skywalking-ui:$SW_VERSION"
+# Horizon UI ships on Docker Hub under skywalking-ui with a horizon- tag prefix.
+$env:UI_IMAGE = "apache/skywalking-ui:horizon-$SW_HORIZON_UI_VERSION"
 
 # Unset the SW_STORAGE environment variable at the start of the script
 Remove-Item Env:\SW_STORAGE -ErrorAction Ignore
@@ -86,10 +89,20 @@ if (Test-Path -Path $COMPOSE_FILE_PATH) {
 
 if ($DOWNLOAD) {
     Invoke-WebRequest -Uri "https://github.com/apache/skywalking/raw/master/docker/docker-compose.yml" -OutFile $COMPOSE_FILE_PATH
-    Write-Host "Downloaded SkyWalking Docker Compose manifest to the current directory...`n"
+    # The ui service bind-mounts ./horizon.yaml relative to the compose file, and
+    # the image reads its OAP URLs and login users only from there, so it has to
+    # sit beside the manifest or compose fails on the missing mount.
+    Invoke-WebRequest -Uri "https://github.com/apache/skywalking/raw/master/docker/horizon.yaml" -OutFile $HORIZON_CONFIG_PATH
+    Write-Host "Downloaded SkyWalking Docker Compose manifest and Horizon UI config to the current directory...`n"
 }
 else {
     Write-Host "Attempting to reuse the existing SkyWalking Docker Compose manifest from the current directory.`n"
+    # A manifest kept from an older run predates the Horizon UI config; fetch it
+    # rather than letting compose fail on the missing mount.
+    if (-not (Test-Path -Path $HORIZON_CONFIG_PATH)) {
+        Invoke-WebRequest -Uri "https://github.com/apache/skywalking/raw/master/docker/horizon.yaml" -OutFile $HORIZON_CONFIG_PATH
+        Write-Host "Downloaded the missing Horizon UI config beside it.`n"
+    }
 }
 
 # If SW_STORAGE is not set, prompt the user to select a storage option
@@ -131,7 +144,7 @@ if ($DETACHED) {
 }
 
 # Attempt to start Docker compose
-Write-Host "Starting to set up SkyWalking ($SW_VERSION) with $env:SW_STORAGE storage, this might take a while...`n"
+Write-Host "Starting to set up SkyWalking ($SW_VERSION) with Horizon UI ($SW_HORIZON_UI_VERSION) and $env:SW_STORAGE storage, this might take a while...`n"
 
 Invoke-Expression $composeCommand
 

--- a/content/quickstart-docker.ps1
+++ b/content/quickstart-docker.ps1
@@ -162,4 +162,9 @@ else {
     Write-Host "To find SkyWalking Docs, follow the link to our documentation site https://skywalking.apache.org/docs/.`n"
 
     Write-Host "To stop SkyWalking, run 'docker compose --project-name=skywalking-quickstart down'.`n"
+
+    Write-Host "Sign in to the UI at http://localhost:8080 with:"
+    Write-Host "  username: skywalking"
+    Write-Host "  password: skywalking"
+    Write-Host "These are quickstart credentials - change them before exposing the UI beyond localhost.`n"
 }

--- a/content/quickstart-docker.ps1
+++ b/content/quickstart-docker.ps1
@@ -91,8 +91,10 @@ if ($DOWNLOAD) {
     Invoke-WebRequest -Uri "https://github.com/apache/skywalking/raw/master/docker/docker-compose.yml" -OutFile $COMPOSE_FILE_PATH
     # The ui service bind-mounts ./horizon.yaml relative to the compose file, and
     # the image reads its OAP URLs and login users only from there, so it has to
-    # sit beside the manifest or compose fails on the missing mount.
-    Invoke-WebRequest -Uri "https://github.com/apache/skywalking/raw/master/docker/horizon.yaml" -OutFile $HORIZON_CONFIG_PATH
+    # sit beside the manifest or compose fails on the missing mount. Served from
+    # this site rather than a branch tip, so it stays in step with the versions
+    # pinned above.
+    Invoke-WebRequest -Uri "https://skywalking.apache.org/horizon.yaml" -OutFile $HORIZON_CONFIG_PATH
     Write-Host "Downloaded SkyWalking Docker Compose manifest and Horizon UI config to the current directory...`n"
 }
 else {
@@ -100,7 +102,7 @@ else {
     # A manifest kept from an older run predates the Horizon UI config; fetch it
     # rather than letting compose fail on the missing mount.
     if (-not (Test-Path -Path $HORIZON_CONFIG_PATH)) {
-        Invoke-WebRequest -Uri "https://github.com/apache/skywalking/raw/master/docker/horizon.yaml" -OutFile $HORIZON_CONFIG_PATH
+        Invoke-WebRequest -Uri "https://skywalking.apache.org/horizon.yaml" -OutFile $HORIZON_CONFIG_PATH
         Write-Host "Downloaded the missing Horizon UI config beside it.`n"
     }
 }

--- a/content/quickstart-docker.sh
+++ b/content/quickstart-docker.sh
@@ -58,8 +58,9 @@ curl -fsSL https://github.com/apache/skywalking/raw/master/docker/docker-compose
 
 # The ui service bind-mounts ./horizon.yaml relative to the compose file, and the
 # image reads its OAP URLs and login users only from there, so it has to land in
-# the same directory or compose fails on the missing mount.
-curl -fsSL https://github.com/apache/skywalking/raw/master/docker/horizon.yaml -o "$temp_dir/horizon.yaml"
+# the same directory or compose fails on the missing mount. Served from this site
+# rather than a branch tip, so it stays in step with the versions pinned above.
+curl -fsSL https://skywalking.apache.org/horizon.yaml -o "$temp_dir/horizon.yaml"
 
 # If SW_STORAGE is not set, prompt the user to select a storage option
 if [ -z "$SW_STORAGE" ]; then

--- a/content/quickstart-docker.sh
+++ b/content/quickstart-docker.sh
@@ -20,7 +20,8 @@ set -e
 
 SW_STORAGE=
 
-SW_VERSION=${SW_VERSION:-10.4.0}
+SW_VERSION=${SW_VERSION:-11.0.0}
+SW_HORIZON_UI_VERSION=${SW_HORIZON_UI_VERSION:-1.0.0}
 SW_BANYANDB_VERSION=${SW_BANYANDB_VERSION:-0.11.0}
 
 usage() {
@@ -55,9 +56,10 @@ temp_dir=$(mktemp -d)
 
 curl -fsSL https://github.com/apache/skywalking/raw/master/docker/docker-compose.yml -o "$temp_dir/docker-compose.yml"
 
-# Patch OAP health check for SkyWalking 10.4.0+ (curl not available in image)
-perl -pi -e "s|curl http://localhost:12800/internal/l7check|bash -c 'echo >/dev/tcp/localhost/12800'|" "$temp_dir/docker-compose.yml"
-sed -i 's|start_period: 10s|start_period: 120s|g' "$temp_dir/docker-compose.yml"
+# The ui service bind-mounts ./horizon.yaml relative to the compose file, and the
+# image reads its OAP URLs and login users only from there, so it has to land in
+# the same directory or compose fails on the missing mount.
+curl -fsSL https://github.com/apache/skywalking/raw/master/docker/horizon.yaml -o "$temp_dir/horizon.yaml"
 
 # If SW_STORAGE is not set, prompt the user to select a storage option
 if [ -z "$SW_STORAGE" ]; then
@@ -82,9 +84,9 @@ esac
 
 export BANYANDB_IMAGE=apache/skywalking-banyandb:${SW_BANYANDB_VERSION}
 export OAP_IMAGE=apache/skywalking-oap-server:${SW_VERSION}
-export UI_IMAGE=apache/skywalking-ui:${SW_VERSION}
+export UI_IMAGE=apache/skywalking-ui:horizon-${SW_HORIZON_UI_VERSION}
 
-echo "Installing SkyWalking ${SW_VERSION} with ${SW_STORAGE} storage..."
+echo "Installing SkyWalking ${SW_VERSION} with Horizon UI ${SW_HORIZON_UI_VERSION} and ${SW_STORAGE} storage..."
 
 docker compose -f "$temp_dir/docker-compose.yml" \
   --project-name=skywalking-quickstart \

--- a/content/quickstart-docker.sh
+++ b/content/quickstart-docker.sh
@@ -103,3 +103,9 @@ fi
 echo "To find SkyWalking Docs, follow the link to our documentation site https://skywalking.apache.org/docs/."
 
 echo "To stop SkyWalking, run 'docker compose --project-name=skywalking-quickstart down'."
+
+echo ""
+echo "Sign in to the UI at http://localhost:8080 with:"
+echo "  username: skywalking"
+echo "  password: skywalking"
+echo "These are quickstart credentials — change them before exposing the UI beyond localhost."


### PR DESCRIPTION
Brings `content/quickstart-docker.sh` and `content/quickstart-docker.ps1` up to the current releases. Two of the changes are not version bumps — they are fixes for things that would break the quickstart as it stands.

## Versions

| | bash was | ps1 was | now |
|---|---|---|---|
| `SW_VERSION` | 10.4.0 | 10.2.0 | **11.0.0** |
| `SW_HORIZON_UI_VERSION` | — | — | **1.0.0** (new) |
| `SW_BANYANDB_VERSION` | 0.11.0 | 0.8.0 | **0.11.0** |

The PowerShell script had drifted a long way further behind than the shell one.

## The UI image changed, not just its tag

`apache/skywalking`'s `docker/docker-compose.yml` now defaults `UI_IMAGE` to the Horizon image — the legacy UI is gone from the repo, and **`apache/skywalking-ui:11.0.0` does not exist**. Both scripts were forcing `apache/skywalking-ui:${SW_VERSION}`, so they would fail on a bad image reference.

Worth flagging for reviewers, because the obvious fix is wrong: the released Horizon image is on **Docker Hub as `apache/skywalking-ui:horizon-<version>`**. The `ghcr.io/apache/skywalking-horizon-ui` path that upstream's `docker/README.md` and `.env` point at carries only commit-SHA tags and `latest` — there is no `1.0.0` there, so pinning a release against the documented path would 404.

## The scripts never downloaded `horizon.yaml`

The `ui` service bind-mounts `./horizon.yaml` relative to the compose file, and the image reads its OAP URLs and login users **only** from that file — there are no env vars for them. Fetching just `docker-compose.yml` leaves compose failing on the missing mount. Both scripts now download it alongside; the PowerShell one also back-fills it when the user reuses a manifest from an earlier run that predates Horizon.

## Two dead patch lines removed

The shell script carried a `perl` rewrite of the OAP health check and a `sed` on `start_period: 10s`. Upstream's compose already ships the `/dev/tcp` probe and `start_period: 90s`, so neither matched anything.

## Verification

Fetched the real manifest and config into a temp dir exactly as the script does, exported the same three image variables, and ran compose against it:

- `docker compose config` resolves `apache/skywalking-oap-server:11.0.0`, `apache/skywalking-ui:horizon-1.0.0`, `apache/skywalking-banyandb:0.11.0`, and the `horizon.yaml` mount resolves to a real file.
- `up --dry-run` creates the containers cleanly on **both** the `elasticsearch` and `banyandb` profiles.
- All three images confirmed pullable via `docker manifest inspect`.
- `sh -n` passes on the shell script.

The PowerShell script is reviewed by eye only — no `pwsh` on the machine this was written on, so a Windows check before merge would be worth having.