### PR TITLE
Docs: host Helm and SWCK docs on the website

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -330,10 +330,17 @@
       icon: helm
       description: SkyWalking Kubernetes Helm repository provides ways to install and configure SkyWalking in a Kubernetes cluster. The scripts are written in Helm 3.
       user: apache
-      repo: skywalking-kubernetes
+      repo: skywalking-helm
+      repoUrl: https://github.com/apache/skywalking-helm.git
       docs:
-        - version: v4.9.0
-          link: https://github.com/apache/skywalking-kubernetes/tree/v4.9.0
+        - version: Next
+          link: /docs/skywalking-helm/next/readme/
+        - version: Latest
+          link: /docs/skywalking-helm/latest/readme/
+          commitId: 6fe2c783ba2639b0d9ae62edde25fb4d60f3b5e6
+        - version: v5.0.0
+          link: /docs/skywalking-helm/v5.0.0/readme/
+          commitId: 6fe2c783ba2639b0d9ae62edde25fb4d60f3b5e6
     - name: SkyWalking Cloud on Kubernetes
       icon: kubernetes
       description: A bridge project between Apache SkyWalking and Kubernetes.
@@ -345,10 +352,10 @@
           link: /docs/skywalking-swck/next/readme/
         - version: Latest
           link: /docs/skywalking-swck/latest/readme/
-          commitId: d299bc05ee230f5f366584054db5b099ca60166f
-        - version: v0.10.0
-          link: /docs/skywalking-swck/v0.10.0/readme/
-          commitId: d299bc05ee230f5f366584054db5b099ca60166f
+          commitId: 29a5ea771330f8b205a9e3a9a876928a1d8914e5
+        - version: v0.11.0
+          link: /docs/skywalking-swck/v0.11.0/readme/
+          commitId: 29a5ea771330f8b205a9e3a9a876928a1d8914e5
 - type: Protocol
   description:
   list:


### PR DESCRIPTION
Both repos carry `docs/` with a `menu.yml`, so their documentation can be rendered by the site instead of linking out to GitHub.

| component | before | after |
|---|---|---|
| **Kubernetes Helm** | GitHub link, single `v4.9.0` tree | `Next` / `Latest` / `v5.0.0`, website-hosted |
| **SWCK** | `Next` / `Latest` / `v0.10.0` | `Next` / `Latest` / `v0.11.0` |

`Latest` and the versioned entry share a commitId in both cases, so `seo/doc-canonical-map.html` points the versioned tree at `/latest/` rather than letting the duplicate pair compete in search.

## Two changes that go beyond a version bump

**Helm's `v4.9.0` entry is dropped, not kept alongside.** A component cannot mix hosted and GitHub-linked entries: `docs.js` runs *every* entry through `doc.sh` once `repoUrl` is present, and an external `https://github.com/…/tree/vX` link then yields a bogus local path and dies at `cp ./docs/menu.yml` under `set -o errexit`, taking the whole build with it.

**`repo` moves from `skywalking-kubernetes` to `skywalking-helm`**, matching the upstream rename that the old name now only reaches by redirect. That puts the docs at `/docs/skywalking-helm/…`, which breaks nothing because this component had no website doc URLs before. It also fixes a latent gap — `apache/skywalking-kubernetes` has no entry in `data/stars.yml`, so that card has never shown a star count.

## Verification

Ran `npm run docs` — the same generation CI performs, clones and all — then a full `hugo` build:

- Exit 0, no errors; all six sidebars generated.
- Trees build: helm `next` / `latest` / `v5.0.0`, swck `next` / `latest` / `v0.11.0`.
- Cards read `Next / v5.0.0` and `Next / v0.11.0`, both with "Read docs" → `/latest/readme/`, and **no GitHub tree links left** on either.
- In-page version switchers offer `next / latest / <release>`; canonicals resolve to `/latest/readme/`.
- `v0.10.0` is gone from the generated sidebars too, so nothing references it.

Generated artifacts are not included — `layouts/projectdoc/baseof.html` and `static/images/*.png` were reverted after the local build, since `build-with-docs` regenerates them.

## Two things worth a reviewer's judgement

**Neither tag is a published release.** `v5.0.0` and `v0.11.0` exist as git tags but have no GitHub release object, and the ASF dist still carries helm `4.9.0` and swck `0.10.0`. So the docs page will advertise v5.0.0 / v0.11.0 while `releases.yml` and the downloads page still offer 4.9.0 / 0.10.0. Coherent if those votes are in flight; worth a second look if not.

**Removing swck `v0.10.0` retires 17 currently published pages.** `/docs/skywalking-swck/v0.10.0/…` is live and indexed today and will 404 after this deploys. Nothing on the site links to it, so there are no internal dead links, but external links and search results will break.