### PR TITLE
Close floating dropdowns when clicking outside them

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,40 @@
+{{- /* Overrides themes/docsy/layouts/partials/hooks/body-end.html, called at the end
+       of the theme's scripts.html — which every one of our baseof templates loads.
+       The theme's own body-end only carries the Algolia docsearch placeholder, kept
+       verbatim below so overriding it loses nothing. */ -}}
+{{ with .Site.Params.algolia_docsearch }}
+<!-- scripts for algolia docsearch -->
+{{ end }}
+
+{{- /* Dismiss floating <details> dropdowns.
+
+       A native <details> stays open until its own summary is clicked again, so
+       clicking anywhere else left the panel hanging over the page. Close them on an
+       outside click and on Escape, and let opening one close the others so only a
+       single panel is ever up.
+
+       Scoped to the floating dropdowns by class. .dl-archived is deliberately not in
+       the list: it is an inline accordion rather than a floating panel, and should
+       stay where the reader put it. */ -}}
+<script>
+  (function () {
+    var SEL = 'details.docs-ver, details.dl-more, details.topic-filter';
+
+    function closeAll(except) {
+      document.querySelectorAll(SEL).forEach(function (d) {
+        if (d !== except && d.open) { d.open = false; }
+      });
+    }
+
+    // Click: a click inside a dropdown keeps that one open and closes the rest;
+    // a click anywhere else closes all of them.
+    document.addEventListener('click', function (e) {
+      var target = e.target instanceof Element ? e.target.closest(SEL) : null;
+      closeAll(target);
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' || e.key === 'Esc') { closeAll(null); }
+    });
+  })();
+</script>


### PR DESCRIPTION
The docs **versions** picker stayed open after you clicked elsewhere on the page — the only way to dismiss it was to find its `summary` again and click that.

The cause is plain `<details>` behaviour: a native `<details>` stays open until its own summary is toggled, and nothing on the site was closing it. The same pattern is used by two other dropdowns, so all three had the bug:

| dropdown | where |
|---|---|
| `details.docs-ver` | docs landing — the reported one |
| `details.dl-more` | downloads cards, the "+N more" version list |
| `details.topic-filter` | blog list (EN and 中文) |

## Behaviour now

- Clicking anywhere outside closes the open panel.
- **Escape** closes it too.
- Opening one closes the others, so only a single panel is ever up.
- Clicking *inside* an open panel leaves it open, so the version links stay reachable.

`details.dl-archived` is deliberately **not** included — it is an inline accordion on the downloads page rather than a floating panel, and should stay where the reader put it.

## Where it is wired

A new `layouts/partials/hooks/body-end.html`, overriding the theme's hook of the same name. That hook is called from the theme's `scripts.html`, which every one of our `baseof` templates already loads — so one file covers docs, downloads, blog and zh, and the theme stays unforked. It is the same approach `hooks/head-end.html` uses to carry the SEO partials.

The theme's own `body-end.html` holds nothing but an Algolia docsearch placeholder, which is kept verbatim in the override so nothing is lost.

## Verification

Driven in a real browser against a local build, not just read:

```
1. open first via summary        -> open=true
2. click elsewhere on the page   -> open=false   (was the bug)
3. open a second one             -> first=false second=true
4. Escape                        -> first=false second=false
5. click inside the open panel   -> open=true    (must stay open)
```

Repeated across all three dropdown kinds, and confirmed `.dl-archived` still stays open after an outside click:

```
downloads .dl-more                 opened=true  after outside click=false
downloads .dl-archived (accordion) opened=true  after outside click=true
blog .topic-filter                 opened=true  after outside click=false
```

Also confirmed the script is emitted exactly once on each of `/docs/`, `/downloads/`, `/blog/` and `/zh/`.