### PR TITLE
Downloads: link the Helm chart tarball on the Kubernetes Helm card

### DIFF
--- a/data/releases.yml
+++ b/data/releases.yml
@@ -796,6 +796,25 @@
               link: https://archive.apache.org/dist/skywalking/helm/4.9.0/skywalking-helm-4.9.0-src.tgz.asc
             - name: sha512
               link: https://archive.apache.org/dist/skywalking/helm/4.9.0/skywalking-helm-4.9.0-src.tgz.sha512
+      distribution:
+        - version: v5.0.0
+          date: Sep. 1st, 2026
+          downloadLink:
+            - name: Helm chart
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/helm/5.0.0/skywalking-helm-5.0.0.tgz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/helm/5.0.0/skywalking-helm-5.0.0.tgz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/helm/5.0.0/skywalking-helm-5.0.0.tgz.sha512
+        - version: v4.9.0
+          date: May. 6th, 2026
+          downloadLink:
+            - name: Helm chart
+              link: https://archive.apache.org/dist/skywalking/helm/4.9.0/skywalking-helm-4.9.0.tgz
+            - name: asc
+              link: https://archive.apache.org/dist/skywalking/helm/4.9.0/skywalking-helm-4.9.0.tgz.asc
+            - name: sha512
+              link: https://archive.apache.org/dist/skywalking/helm/4.9.0/skywalking-helm-4.9.0.tgz.sha512
     - name: SkyWalking Cloud on Kubernetes
       icon: kubernetes
       description: A bridge project between Apache SkyWalking and Kubernetes.


### PR DESCRIPTION
Apache publishes **two** files for each Helm chart release. The downloads page linked only one.

```
$ curl -s https://downloads.apache.org/skywalking/helm/5.0.0/
skywalking-helm-5.0.0-src.tgz      <- linked on the page  (src ↓)
skywalking-helm-5.0.0.tgz          <- NOT linked anywhere
```

The second one is the packaged chart — what `helm install` actually consumes. With no link for it, the Kubernetes Helm card rendered a **Source section and nothing else**, and the chart was reachable only by browsing the ASF mirror by hand.

## Change

Adds a Distribution section to the Kubernetes Helm card carrying the chart for:

- **5.0.0** — `closer.cgi` for the download, `downloads.apache.org` for `.asc` / `.sha512`
- **4.9.0** — `archive.apache.org` throughout

labelled `Helm chart`, matching what the SkyWalking Cloud on Kubernetes card already shows.

## Why it went unnoticed

Not a 5.0.0 regression — 4.9.0 ships a chart too, with full signatures, and was equally unlinked. It only became visible because SWCK 0.11.0 began publishing its own chart in #912, which left two adjacent cards disagreeing about whether a released chart gets a link.

For reference, the three chart artifacts on the site now behave consistently, and the differences between them are deliberate:

| chart | released from | where it appears |
|---|---|---|
| SkyWalking Helm | `apache/skywalking-helm` | Distribution row on the Kubernetes Helm card — **this PR** |
| SWCK | `apache/skywalking-swck`, new in 0.11.0 | Distribution row on the SWCK card (#912) |
| BanyanDB Helm | `apache/skywalking-banyandb-helm`, a separate project | its own card |

## Verification

All six new links probed — every one returns 200, across both the current-release and archive paths. Full Hugo build: the card renders `Source → src` and `Distribution → Helm chart`, with 4.9.0 behind "+1 more" in both sections.