### PR TITLE
feat: add skywalking-eyes 0.9.0

### DIFF
--- a/content/events/release-apache-skywalking-eyes-0-9-0/index.md
+++ b/content/events/release-apache-skywalking-eyes-0-9-0/index.md
@@ -1,0 +1,54 @@
+---
+title: "Release Apache SkyWalking Eyes 0.9.0"
+date: 2026-08-28
+author: "[SkyWalking Team](/team)"
+description: "Release Apache SkyWalking Eyes 0.9.0."
+---
+
+SkyWalking Eyes 0.9.0 is released. Go to [downloads](/downloads) page to find release tars.
+
+## What's Changed
+* chore(deps): bump up go version by @kezhenxu94 in https://github.com/apache/skywalking-eyes/pull/251
+* Bump golang.org/x/crypto from 0.39.0 to 0.45.0 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/253
+* Bump github.com/sirupsen/logrus from 1.9.0 to 1.9.1 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/254
+* 🐛 fix(deps): Ruby: local path & recursive resolution of deps by @pboling in https://github.com/apache/skywalking-eyes/pull/255
+* Fix: Compatibility issue with Node.js 24 (related to apache/skywalking#13517) by @XL-Zhao-23 in https://github.com/apache/skywalking-eyes/pull/252
+* fix: improve error message formatting in license template lookup by @kezhenxu94 in https://github.com/apache/skywalking-eyes/pull/256
+* feat: check headers concurrently by @ZacBlanco in https://github.com/apache/skywalking-eyes/pull/257
+* Bump github.com/go-git/go-git/v5 from 5.13.0 to 5.16.5 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/258
+* feat: add Pkl language support by @jhult in https://github.com/apache/skywalking-eyes/pull/261
+* feat: add Inko language support by @jhult in https://github.com/apache/skywalking-eyes/pull/262
+* fix: Fish completion script corrupted by INFO log message by @jhult in https://github.com/apache/skywalking-eyes/pull/259
+* fix: add helpful error message for git repository issues by @jhult in https://github.com/apache/skywalking-eyes/pull/260
+* Bump github.com/cloudflare/circl from 1.6.1 to 1.6.3 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/264
+* Bump setup-go to v6 by @adoroszlai in https://github.com/apache/skywalking-eyes/pull/265
+* feat: extend GoModResolver to support any valid Go *.mod file by @ivankatliarchuk in https://github.com/apache/skywalking-eyes/pull/268
+* ci: add golangci-lint GitHub Actions workflow by @ivankatliarchuk in https://github.com/apache/skywalking-eyes/pull/269
+* fix: respect specified paths in git repository by @jhult in https://github.com/apache/skywalking-eyes/pull/263
+* ci(action): harden header GitHub action by @domodwyer in https://github.com/apache/skywalking-eyes/pull/270
+* build(deps): bump github.com/go-git/go-git/v5 from 5.16.5 to 5.18.0 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/271
+* fix: corrrect RoundBracketAsterisk comment style by @bthuilot in https://github.com/apache/skywalking-eyes/pull/272
+* build(deps): bump github.com/go-git/go-git/v5 from 5.18.0 to 5.19.1 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/275
+* feat: add `header diff` command to show header differences by @wu-sheng in https://github.com/apache/skywalking-eyes/pull/276
+* Add support for Ruby, ERB and slim by @afriqs in https://github.com/apache/skywalking-eyes/pull/266
+* build(deps): bump golang.org/x/net from 0.53.0 to 0.55.0 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/277
+* build(deps): bump golang.org/x/crypto from 0.51.0 to 0.52.0 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/278
+* fix: don't treat mid-file #! strings as Python shebangs by @cmaluend in https://github.com/apache/skywalking-eyes/pull/279
+* fix: pin docker/login-action to an ASF-approved commit SHA by @wu-sheng in https://github.com/apache/skywalking-eyes/pull/280
+* build(deps): bump github.com/go-git/go-git/v5 from 5.19.1 to 5.19.2 by @dependabot[bot] in https://github.com/apache/skywalking-eyes/pull/281
+* feat: resolve dependencies of pnpm-managed Node.js projects by @wu-sheng in https://github.com/apache/skywalking-eyes/pull/282
+* docs: fix typo seperated -> separated by @vaibhav8a in https://github.com/apache/skywalking-eyes/pull/283
+
+## New Contributors
+* @XL-Zhao-23 made their first contribution in https://github.com/apache/skywalking-eyes/pull/252
+* @ZacBlanco made their first contribution in https://github.com/apache/skywalking-eyes/pull/257
+* @jhult made their first contribution in https://github.com/apache/skywalking-eyes/pull/261
+* @adoroszlai made their first contribution in https://github.com/apache/skywalking-eyes/pull/265
+* @ivankatliarchuk made their first contribution in https://github.com/apache/skywalking-eyes/pull/268
+* @domodwyer made their first contribution in https://github.com/apache/skywalking-eyes/pull/270
+* @bthuilot made their first contribution in https://github.com/apache/skywalking-eyes/pull/272
+* @afriqs made their first contribution in https://github.com/apache/skywalking-eyes/pull/266
+* @cmaluend made their first contribution in https://github.com/apache/skywalking-eyes/pull/279
+* @vaibhav8a made their first contribution in https://github.com/apache/skywalking-eyes/pull/283
+
+**Full Changelog**: https://github.com/apache/skywalking-eyes/compare/v0.8.0...v0.9.0

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -424,8 +424,8 @@
       user: apache
       repo: skywalking-eyes
       docs:
-        - version: v0.8.0
-          link: https://github.com/apache/skywalking-eyes/tree/v0.8.0
+        - version: v0.9.0
+          link: https://github.com/apache/skywalking-eyes/tree/v0.9.0
     - name: SkyWalking Infra E2E
       icon: skywalking-agent-test-tool
       description: An End-to-End Testing framework that aims to help developers to set up, debug, and verify E2E tests with ease.

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -933,25 +933,25 @@
       icon: skywalking-eyes
       description: A full-featured license tool to check and fix license headers and resolve dependencies' licenses.
       source:
-        - version: v0.8.0
-          date: Oct. 27th, 2025
+        - version: v0.9.0
+          date: Aug. 28th, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/eyes/0.8.0/skywalking-license-eye-0.8.0-src.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/eyes/0.9.0/skywalking-license-eye-0.9.0-src.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/eyes/0.8.0/skywalking-license-eye-0.8.0-src.tgz.asc
+              link: https://downloads.apache.org/skywalking/eyes/0.9.0/skywalking-license-eye-0.9.0-src.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/eyes/0.8.0/skywalking-license-eye-0.8.0-src.tgz.sha512
+              link: https://downloads.apache.org/skywalking/eyes/0.9.0/skywalking-license-eye-0.9.0-src.tgz.sha512
       distribution:
-        - version: v0.8.0
-          date: Oct. 27th, 2025
+        - version: v0.9.0
+          date: Aug. 28th, 2026
           downloadLink:
             - name: tar
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/eyes/0.8.0/skywalking-license-eye-0.8.0-bin.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/eyes/0.9.0/skywalking-license-eye-0.9.0-bin.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/eyes/0.8.0/skywalking-license-eye-0.8.0-bin.tgz.asc
+              link: https://downloads.apache.org/skywalking/eyes/0.9.0/skywalking-license-eye-0.9.0-bin.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/eyes/0.8.0/skywalking-license-eye-0.8.0-bin.tgz.sha512
+              link: https://downloads.apache.org/skywalking/eyes/0.9.0/skywalking-license-eye-0.9.0-bin.tgz.sha512
     - name: SkyWalking Infra E2E
       icon: skywalking-agent-test-tool
       description: An End-to-End Testing framework that aims to help developers to set up, debug, and verify E2E tests with ease.


### PR DESCRIPTION
Add the 0.9.0 release event post, and point `data/releases.yml` and `data/docs.yml` at the 0.9.0 artifacts and the `v0.9.0` tag.

- Post body is the v0.9.0 release notes, matching the 0.8.0 post (`CHANGES.md` in skywalking-eyes just points at the GitHub release notes).
- Date is Aug. 28th, 2026, when the artifacts landed on `downloads.apache.org`.
- Eyes keeps a single latest entry in both data files, so the 0.8.0 entries are replaced rather than demoted to `archive.apache.org`, as in #797.