### PR TITLE
Docs: add AI Sessionizer, and fold Grafana Plugins into SkyWalking Servers

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -101,14 +101,9 @@
         - version: v1.0.0
           link: /docs/skywalking-horizon-ui/v1.0.0/readme/
           commitId: 19ca126d9bd931b51af86e31086bf615dad3decd
-- type: Grafana Plugins
-  description:
-  list:
-    - name:
-      descriptionItem: Metrics visualization on Grafana is supported through PromQL. Please refer to the primary docs for more details.
-    - name: Plugin for Service Topology
+    - name: Grafana Plugin for Service Topology
       icon: skywalking
-      description: SkyWalking Grafana Plugins provide extensions to visualize topology on Grafana.
+      description: SkyWalking Grafana Plugins provide extensions to visualize topology on Grafana. Metrics visualization is supported through PromQL.
       user: apache
       repo: skywalking-grafana-plugins
       docs:
@@ -116,6 +111,15 @@
           link: https://github.com/apache/skywalking-grafana-plugins
         - version: v0.1.0
           link: https://github.com/apache/skywalking-grafana-plugins/tree/v0.1.0
+    - name: AI Sessionizer
+      icon: skywalking
+      description: Conversation-level observability, measurement and export for long-lived AI agents.
+      user: apache
+      repo: skywalking-ai-sessionizer
+      repoUrl: https://github.com/apache/skywalking-ai-sessionizer.git
+      docs:
+        - version: Next
+          link: /docs/skywalking-ai-sessionizer/next/readme/
 - type: Agents
   description:
   list:


### PR DESCRIPTION
## AI Sessionizer

[`apache/skywalking-ai-sessionizer`](https://github.com/apache/skywalking-ai-sessionizer) already carries `docs/` with a `menu.yml`, so its documentation is **hosted on the site** rather than linked out to GitHub. Seven pages render: Welcome, four under Concepts and Designs, two under Adapters.

**A `Next` entry only** — no `Latest`, no version. The repo has no tags and no releases, and pinning a versioned entry to a `main` commit would publish docs for a version that does not exist. Nothing was added to `releases.yml`; there is nothing to download yet.

This is the site's first `Next`-only component, so the card's primary-link path ("the `Latest` entry if present, else the first one") was verified rather than assumed: Read docs resolves to `/docs/skywalking-ai-sessionizer/next/readme/`, and no versions dropdown renders.

## Grafana Plugins folded in

`Grafana Plugins` is no longer a top-level section — the page goes from 11 sections to 10. Its single project moves into **SkyWalking Servers**, beside the sessionizer:

> SkyWalking → (Experimental) GraalVM Distro → Horizon UI → Grafana Plugin for Service Topology → AI Sessionizer

Two consequences of dropping the section header, both worth a look:

- **The card is renamed** `Plugin for Service Topology` → `Grafana Plugin for Service Topology`. Without the header, the old name no longer said what it plugs into. This changes its anchor from `#PluginforServiceTopology` to `#GrafanaPluginforServiceTopology`, so any existing deep link to it breaks.
- **The section's standalone note card is folded into the entry.** The old section led with a text-only tile — *"Metrics visualization on Grafana is supported through PromQL…"*. With no section left to preface it would have rendered as a stray tile among project cards, so its substance moved into that entry's own description, trimmed to fit the card's three-line clamp (the untrimmed version truncated mid-sentence). The note cards on Archived / Ecosystem / Ecosystem Retired are untouched.

The merged section now mixes a GitHub-linked entry with website-hosted ones. That is safe and already precedented in five other sections — `docs.js` guards on `repoUrl` **per item** (line 153), not per section.

## Verification

`npm run docs` — the same generation CI runs, clones and all — then a full `hugo` build:

- Generation exit 0, no errors; sessionizer sidebar generated.
- All seven sessionizer pages build; its doc page renders with sidebar and a `next`-only version switcher.
- Grafana card keeps its GitHub Read-docs link and its `v0.1.0` dropdown.
- Ten sections on the landing page, `Grafana Plugins` gone, three note cards remaining (the correct ones).
- Generated artifacts excluded — `layouts/projectdoc/baseof.html` and `static/images/*.png` reverted after the local build, since `build-with-docs` regenerates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)