### PR TITLE
Update news of BanyanDB Helm 0.7.0

### DIFF
--- a/content/events/release-apache-skywalking-banyandb-helm-0-7-0/index.md
+++ b/content/events/release-apache-skywalking-banyandb-helm-0-7-0/index.md
@@ -1,0 +1,17 @@
+---
+title: Release Apache SkyWalking BanyanDB Helm 0.7.0
+date: 2026-09-08
+author: SkyWalking Team
+---
+
+SkyWalking BanyanDB Helm 0.7.0 is released. Go to [downloads](/downloads) page to find release tars.
+
+#### Features
+
+- Add optional canopy web console deployment (`canopy.*`): Deployment + Service + optional Ingress for standalone and cluster modes, with a generated default admin user (strong random password, stable across upgrades; retrievable from the install notes or the `<release>-canopy-auth` Secret). The BanyanDB HTTP services now also expose the observability port 2121 so the console's monitoring target works in both modes.
+- Remove etcd support (breaking change). If upgrading, remove `etcd-client.*` and `cluster.*.tls.etcdSecretName` from your values overrides.
+- Disable the lifecycle metrics collector when the lifecycle sidecar container is disabled.
+- Enable FODC panic/crash diagnostics collection by default. Configure via `cluster.fodc.agent.config.crashCollection.{enabled,dir,maxArtifacts,diagnosisMemoryPercent}`.
+- Add FODC memory-pressure pprof capture for data and liaison nodes. Configure via `cluster.fodc.agent.pressureProfiler.*`.
+- Add trace-pipeline sampler plugin support for data nodes (`plugins.*`): deploy the plugin host/carrier images, mount trusted and third-party plugin directories, and validate the plugin configuration at install time.
+- Validate generated resource names (StatefulSets, Services, Secrets, Deployments) at install/upgrade time to avoid exceeding Kubernetes' 63-byte label limit, failing fast with a clear error instead of at apply time.

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -411,8 +411,8 @@
       docs:
         - version: Next
           link: https://github.com/apache/skywalking-banyandb-helm/blob/master/README.md
-        - version: v0.6.0
-          link: https://github.com/apache/skywalking-banyandb-helm/blob/v0.6.0/README.md
+        - version: v0.7.0
+          link: https://github.com/apache/skywalking-banyandb-helm/blob/v0.7.0/README.md
 - type: Support tools for development and testing
   buttonText: Tools
   description: SkyWalking native tools to support development and testing.

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -916,15 +916,15 @@
       icon: banyan-db
       description: BanyanDB Helm repository provides ways to install and configure BanyanDB. The scripts are written in Helm 3.
       source:
-        - version: v0.6.0
-          date: Apr. 28th, 2026
+        - version: v0.7.0
+          date: Sep. 8th, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb-helm/0.6.0/skywalking-banyandb-helm-0.6.0-src.tgz
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/banyandb-helm/0.7.0/skywalking-banyandb-helm-0.7.0-src.tgz
             - name: asc
-              link: https://downloads.apache.org/skywalking/banyandb-helm/0.6.0/skywalking-banyandb-helm-0.6.0-src.tgz.asc
+              link: https://downloads.apache.org/skywalking/banyandb-helm/0.7.0/skywalking-banyandb-helm-0.7.0-src.tgz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/banyandb-helm/0.6.0/skywalking-banyandb-helm-0.6.0-src.tgz.sha512
+              link: https://downloads.apache.org/skywalking/banyandb-helm/0.7.0/skywalking-banyandb-helm-0.7.0-src.tgz.sha512
 - type: Support tools for development and testing
   buttonText: Tools
   description:


### PR DESCRIPTION
## Summary
- Add release news post for Apache SkyWalking BanyanDB Helm 0.7.0
- Update `data/docs.yml` doc link to v0.7.0
- Update `data/releases.yml` download links to v0.7.0

Same pattern as #838 (the 0.6.0 update).