### PR TITLE
Release Apache SkyWalking GraalVM Distro 0.4.0

### DIFF
--- a/content/events/release-apache-skywalking-graalvm-distro-0-4-0/index.md
+++ b/content/events/release-apache-skywalking-graalvm-distro-0-4-0/index.md
@@ -1,0 +1,41 @@
+---
+title: Release Apache SkyWalking GraalVM Distro 0.4.0
+date: 2026-09-10
+author: SkyWalking Team
+description: "Release Apache SkyWalking GraalVM Distro 0.4.0."
+---
+
+SkyWalking GraalVM Distro 0.4.0 is released. Go to [downloads](https://skywalking.apache.org/downloads/#SkyWalkingGraalVMDistro) page to find release tars.
+
+This release is built on the Apache SkyWalking **v11.0.0** release tag.
+
+### Upstream Sync
+
+- Sync SkyWalking submodule to the upstream **v11.0.0** release tag (`6f1fd78e87`).
+- Wire the admin-server family on the admin host (HTTP `:17128`, admin-internal gRPC `:17129`): `admin-server`, `status` (relocated from the 10.x `status-query` plugin — `/status/*`, `/debugging/*`), `inspect` (SWIP-14 metric catalog, `/inspect/*`), `ui-management` (dashboard-template REST for the Horizon UI, `/ui-management/*`), and `dsl-debugging` (SWIP-13 DSL live debugger). The `status-query` plugin is removed.
+- Adopt every rule file upstream added or reworked: Airflow layer (SWIP-7), BanyanDB self-observability (SWIP-15: reworked `banyandb-service/instance`, new `banyandb-endpoint` and `banyandb-instance-relation`), Node.js and PHP runtime meters, the Envoy TCP access-log LAL rule (`envoy-als-tcp`), iOS (SWIP-11) and mini-program (SWIP-12) OTel rules, Envoy AI Gateway MCP rules, the mini-program log-MAL rules and the `ai_route_type` searchable log tag — all enabled with the upstream defaults.
+- Follow the upstream DSL refactors: rule source attribution (`DslSourceRef`; generated classes are named `{yaml}_L{line}_{rule}` exactly as the JVM distro names them), the DSL class-loading move to `core/dsl`, LAL input-type routing (Envoy HTTP vs TCP entries on the same layer), and `meter-analyzer-config` loading through the shared `Rules` loader.
+- Mirror the new `application.yml` options: the `restSSL*` TLS settings of every HTTP server (present for parity, not verified in the native image), the extended `meterAnalyzerActiveFiles` and `enabledOtelMetricsRules` defaults, and the BanyanDB trace-retention pipeline config.
+- Drop the bundled UI templates: upstream 11.0.0 removed `ui-initialized-templates/` and `UITemplateInitializer`; templates are now managed via `ui-management`.
+
+### DSL Management and Debugging
+
+- **DSL live debugger (SWIP-13) is supported.** The precompiler flips upstream's `DSLDebugCodegenSwitch` before every OAL / MAL / LAL generator pass, so the debug probes and gate holders are compiled into the pre-compiled rule classes; upstream's `dsl-debugging` module then runs unchanged, only flipping gates and reading samples at runtime. `/dsl-debugging/*` sessions work on every bundled rule, and `/runtime/oal/*` lists the OAL catalog.
+- **Read-only rule catalogs.** `GET /runtime/rule/list`, `/runtime/rule/bundled` and `GET /runtime/rule` serve upstream's payloads from the raw MAL/LAL files the precompiler exports at build time, so the Horizon UI's DSL catalog, editor and live-debug pickers list and open every bundled rule (always `BUNDLED`).
+- **Runtime rule hot-update stays unsupported**: `POST /runtime/rule/addOrUpdate|inactivate|delete`, `/runtime/rule/dump`, `/runtime/mal/*` and `/runtime/lal/*` answer a structured HTTP 501 — they generate bytecode at runtime, which a closed-world native image cannot do.
+
+### GraalVM Native Image Compatibility
+
+- Config loading: generate the new `DSLDebuggingModuleConfig` and the BanyanDB `TracePipeline` / `SamplerPluginConfig` nested configs, and emit a no-op dispatch branch for empty `ModuleConfig` types (`InspectModuleConfig`, `UIManagementModuleConfig`).
+- Port the upstream runtime-rule DSL overloads and the `DslSourceRef` signatures into the same-FQCN replacements: meter `DSL.parse(..., ClassPool, ClassLoader)`, `FilterExpression(..., ClassPool, ClassLoader)`, log `DSL.of(..., ClassPool, ClassLoader)`; `LALConfigs` gains upstream's `LAL_CATALOG` / `stampSource`; `HierarchyDefinitionService` loads rules by name from a `ruleName=FQCN` manifest.
+- The precompiler and the MAL comparison tests compose expressions via the real upstream `MetricConvert.formatExp` instead of a hand-rolled replica, fixing pre-compiled class lookup for chained expressions (`.sum` / `.rate` / `.downsampling`).
+- Register protobuf descriptor **editions** classes and **protoc-gen-validate** classes for native-image reflection. protobuf-java 4.33 reflects on these when parsing the BanyanDB measure descriptors; without the metadata, BanyanDB metrics queries failed at runtime with `Generated message class ... missing method`.
+- Register the whole protobuf descriptor closure of the LAL input types (Envoy `HTTPAccessLogEntry` / `TCPAccessLogEntry`, 52 classes down to `Struct` / `Any` / `Timestamp`) with method access, so the `EnvoyAccessLog` content of the `envoy-als` rules and the DSL debug captures no longer degrade to `jsonformat-failed`.
+- Register the distro-only Armeria handlers (`UnsupportedAdminFeatureHandler`, `BundledRuleCatalogHandler`) in `reachability-metadata.json`, so their routes are registered in the native image.
+- Keep `FilterExpression#getLiteral()` in the same-FQCN MAL replacements: the upstream `Analyzer` reads it from the filter probe that only runs with a debug session attached, so a session on a filtered rule file (e.g. `otel-rules/oap.yaml`) killed ingestion with `NoSuchMethodError`.
+
+### Documentation
+
+- Document the admin-server family, the status relocation, the read-only rule catalogs, the live debugger and the unsupported hot-update (HTTP 501) in `distro-policy.md`, `supported-features.md` and `configuration.md`; add the `0.4.0` → `11.0.0` row to `version-mapping.md`; refresh the build-time counts and the manifest table in `docs/internals/dsl-immigration.md`.
+
+All issues and pull requests are [here](https://github.com/apache/skywalking-graalvm-distro/releases/tag/v0.4.0)

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -79,13 +79,15 @@
           link: /docs/skywalking-graalvm-distro/next/readme/
         - version: Latest
           link: /docs/skywalking-graalvm-distro/latest/readme/
-          commitId: 1ab407eb25e2f0ef90f74fd252f277bca9b52910
-        - version: 0.3.0
+          commitId: 1e5dfedd0dfa434c4c339d9d1d1a7f8097d5df97
+        - version: v0.4.0
+          versionName: 0.4.0 (SkyWalking 11.0.0)
+          link: /docs/skywalking-graalvm-distro/v0.4.0/readme/
+          commitId: 1e5dfedd0dfa434c4c339d9d1d1a7f8097d5df97
+        - version: v0.3.0
+          versionName: 0.3.0 (SkyWalking 10.4.0)
           link: /docs/skywalking-graalvm-distro/v0.3.0/readme/
           commitId: 1ab407eb25e2f0ef90f74fd252f277bca9b52910
-        - version: v0.2.1 (10.3.0-dev-64a1795)
-          link: /docs/skywalking-graalvm-distro/v0.2.1/readme/
-          commitId: 5487ed31653fe7a573b0467ae2c4c365204ade5d
     - name: Horizon UI
       icon: skywalking
       description: Apache SkyWalking next-generation UI (Horizon), natively supporting SkyWalking since v11, and partially for v10.

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -208,71 +208,71 @@
       icon: skywalking
       description: A re-distribution of the Apache SkyWalking OAP server based on GraalVM native image. This is experimental.
       source:
-        - version: 0.3.0
+        - version: 0.4.0 (11.0.0)
+          date: Sep. 10th, 2026
+          downloadLink:
+            - name: src
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-src.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-src.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-src.tar.gz.sha512
+        - version: 0.3.0 (10.4.0)
           date: Apr. 10th, 2026
           downloadLink:
             - name: src
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz.sha512
-        - version: 0.2.1 (10.3.0-dev-64a1795)
-          date: Mar. 23rd, 2026
-          downloadLink:
-            - name: src
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz
-            - name: asc
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz.asc
-            - name: sha512
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-src.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-src.tar.gz.sha512
       distribution:
-        - version: 0.3.0
+        - version: 0.4.0 (11.0.0)
+          date: Sep. 10th, 2026
+          downloadLink:
+            - name: Linux AMD64
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-linux-amd64.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-linux-amd64.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-linux-amd64.tar.gz.sha512
+            - name: "|"
+            - name: Linux ARM64
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-linux-arm64.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-linux-arm64.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-linux-arm64.tar.gz.sha512
+            - name: "|"
+            - name: MacOS ARM
+              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-darwin-arm64.tar.gz
+            - name: asc
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-darwin-arm64.tar.gz.asc
+            - name: sha512
+              link: https://downloads.apache.org/skywalking/graalvm-distro/0.4.0/apache-skywalking-graalvm-distro-0.4.0-darwin-arm64.tar.gz.sha512
+        - version: 0.3.0 (10.4.0)
           date: Apr. 10th, 2026
           downloadLink:
             - name: Linux AMD64
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-amd64.tar.gz.sha512
             - name: "|"
             - name: Linux ARM64
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-linux-arm64.tar.gz.sha512
             - name: "|"
             - name: MacOS ARM
-              link: https://www.apache.org/dyn/closer.cgi/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz
             - name: asc
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz.asc
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz.asc
             - name: sha512
-              link: https://downloads.apache.org/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz.sha512
-        - version: 0.2.1 (10.3.0-dev-64a1795)
-          date: Mar. 23rd, 2026
-          downloadLink:
-            - name: Linux AMD64
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz
-            - name: asc
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz.asc
-            - name: sha512
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-amd64.tar.gz.sha512
-            - name: "|"
-            - name: Linux ARM64
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz
-            - name: asc
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz.asc
-            - name: sha512
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-linux-arm64.tar.gz.sha512
-            - name: "|"
-            - name: MacOS ARM
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz
-            - name: asc
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz.asc
-            - name: sha512
-              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.2.1/apache-skywalking-graalvm-distro-0.2.1-darwin-arm64.tar.gz.sha512
+              link: https://archive.apache.org/dist/skywalking/graalvm-distro/0.3.0/apache-skywalking-graalvm-distro-0.3.0-darwin-arm64.tar.gz.sha512
     - name: Horizon UI
       icon: skywalking
       description: Apache SkyWalking next-generation UI (Horizon), natively supporting SkyWalking since v11, and partially for v10.


### PR DESCRIPTION
GraalVM Distro 0.4.0 is out — built on the upstream Apache SkyWalking **v11.0.0** release tag.

### `data/releases.yml`
- Add 0.4.0 (src + linux-amd64 / linux-arm64 / darwin-arm64) on `closer.cgi` + `downloads.apache.org`.
- Demote 0.3.0 to `archive.apache.org` (it has already been moved out of `dist/release` into the archive).
- Drop 0.2.1, keeping two versions listed as before.

### `data/docs.yml`
- `Latest` and the new `v0.4.0` entry both point at `1e5dfedd0dfa434c4c339d9d1d1a7f8097d5df97`, the `v0.4.0` tag commit, so the canonical map keeps pairing `/v0.4.0/` with `/latest/`.
- Keep only `Next` / `Latest` / `v0.4.0` / `v0.3.0`.

Each version is labelled with the upstream OAP version it is built from — 0.4.0 → 11.0.0, 0.3.0 → 10.4.0. In `docs.yml` that label lives in `versionName`, not `version`: `docs.js` uses `version` as a URL path segment when it generates the sidebar (`/docs/${docName}/${version}`) and the version selector substitutes it into the current path.

That also fixes a live bug. The `0.3.0` entry put the version in `version` against a `/v0.3.0/` link, so the generated sidebar points at `/0.3.0/…`:

```
https://skywalking.apache.org/docs/skywalking-graalvm-distro/0.3.0/faq/   -> 404
https://skywalking.apache.org/docs/skywalking-graalvm-distro/v0.3.0/faq/ -> 200
```

Every left-nav link on the v0.3.0 doc pages 404s today. It is now `version: v0.3.0`. The removed `v0.2.1` entry had the same defect.

### Release post
`content/events/release-apache-skywalking-graalvm-distro-0-4-0/index.md`, from `changes/changes.md` at the tag: the v11.0.0 sync and admin-server family, the SWIP-13 DSL live debugger (now supported on the native image) and read-only rule catalogs, native-image compatibility fixes, and docs. Test-only and E2E entries are excluded.

### Verification
- `hugo` builds clean; the downloads page renders all 12 of the new 0.4.0 links.
- `sh ./doc.sh skywalking-graalvm-distro … 1e5dfed… /content/docs/skywalking-graalvm-distro/v0.4.0 skywalking_graalvm_distro_0_4_0` fetches and copies the docs successfully.
- No generated artifacts committed (`layouts/projectdoc/baseof.html`, `data/stars.yml`, `static/images/*` untouched).

Note: the 0.4.0 artifacts are in `dist/release/skywalking/graalvm-distro/0.4.0/` (uploaded Sep 7), but the `downloads.apache.org` mirror had not propagated them at the time of writing. It should catch up on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)