### PR TITLE
Add Sheng Wu's AWS Hero Alliance talk to community calendar

### DIFF
--- a/data/talks.yml
+++ b/data/talks.yml
@@ -49,6 +49,20 @@
 #     slides    optional  slide deck
 
 events:
+  - event: AWS Hero Alliance Talks
+    intro: >-
+      AWS User Group DevSecOps Taiwan's monthly online series featuring AWS Heroes from the Greater China Region, with twelve sessions beginning in September 2026.
+    start: "2026-12-15"
+    location: Online
+    url: https://awsug.com.tw/en/heroes
+    talks:
+      - title: "Beyond Replay: AI Agent Observability with Apache SkyWalking"
+        speaker: 吴晟 Sheng Wu
+        lang: 中文
+        time: 20:00–21:20 GMT+8
+        intro: >-
+          Using Claude Code development sessions to show how SkyWalking connects conversation and execution replay with usage metrics across machines and file change tracking. Covers model and tool calls, sub-agent collaboration, token and cache usage, and diffs linked to their conversation context.
+
   - event: AWS Community Day 2026 Hong Kong
     intro: >-
       A community-organised, full-day AWS event run by the Hong Kong AWS user group — practitioner talks on cloud architecture, operations and observability rather than vendor sessions.


### PR DESCRIPTION
Adds Sheng Wu’s “Beyond Replay: AI Agent Observability with Apache SkyWalking” talk to the community calendar for December 15, 2026, 20:00–21:20 UTC+8. Includes the online location, Chinese presentation language, and summaries based on the [AWS Hero Alliance Talks schedule](https://awsug.com.tw/en/heroes).

Validation: Hugo build passed; verified the upcoming calendar card and generated `.ics` entry, and `git diff --check` passed.
